### PR TITLE
Initial Release

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,6 @@ services:
     build: ./src
     env_file:
       - stack-back.env
-      # - alerts.env
     labels:
       stack-back.volumes: true
       stack-back.volumes.include: 'src'
@@ -12,13 +11,9 @@ services:
       - default
       - global
     volumes:
-      # Map in docker socket
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      # Map local restic repository for dev
       - ./restic_data:/restic_data
-      # Map restic cache
       - ./restic_cache:/cache
-      # Map in project source in dev
       - ./src:/stack-back
   web:
     image: nginx
@@ -28,9 +23,6 @@ services:
     volumes:
       - ./src/tests:/srv/tests
       - ./.vscode:/srv/code
-    environment:
-      - SOME_VALUE=test
-      - ANOTHER_VALUE=1
 
   mysql5:
     image: mysql:5


### PR DESCRIPTION
I found this repo while looking for a simple solution for backing up the volumes in my compose stacks. The original maintainers did some great work on this! Unfortunately, the project was abandoned, and some things have broken over time. I have returned this project to a working state and added some enhancements.

## Updates and Fixes
* Updated pip commands in Dockerfile because current Alpine python3 version no longer allows pip system installs
* Updated Postgres client from the Alpine edge repo because the current Alpine Postgres client package doesn't support Postgres 17
* Updated docker Python package used in `rcb` because original version now throws an error due to deprecated protocol handler when interacting with the docker socket
* Updated restic base image version to the current release

## Enhancements
* Added `--single-transaction` flag to `mysqldump` to prevent inconsistent backups for live databases
* MariaDB environment variables updated to `MARIADB_USER` and `MARIADB_PASSWORD` from `MYSQL_*` to match the supported variables for the official mariadb container image
* If `MYSQL_ROOT_PASSWORD` or `MARIADB_ROOT_PASSWORD` are available, use that for backup instead of the regular user account.
* Created image build and publish workflow to automatically publish the container image on ghcr.io on updates to `master` or tag push / release.
* `.env` template file changed to `.env.template` and added `.env` to `.gitignore` to prevent accidental commits
* Updated README to make examples clear and concise
* Automated tests and release workflow with GitHub Actions