### PR TITLE
stop during backup + arm support

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -38,11 +38,18 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: ./src
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/src/restic_compose_backup/containers.py
+++ b/src/restic_compose_backup/containers.py
@@ -171,6 +171,11 @@ class Container:
     def postgresql_backup_enabled(self) -> bool:
         """bool: If the ``stack-back.postgres`` label is set"""
         return utils.is_true(self.get_label(enums.LABEL_POSTGRES_ENABLED))
+    
+    @property
+    def stop_during_backup(self) -> bool:
+        """bool: If the ``stack-back.volumes.stop-during-backup`` label is set"""
+        return utils.is_true(self.get_label(enums.LABEL_STOP_DURING_BACKUP)) and not self.database_backup_enabled
 
     @property
     def is_backup_process_container(self) -> bool:
@@ -355,6 +360,7 @@ class RunningContainers:
         self.this_container = None
         self.backup_process_container = None
         self.stale_backup_process_containers = []
+        self.stop_during_backup_containers = []
 
         # Find the container we are running in.
         # If we don't have this information we cannot continue
@@ -378,6 +384,10 @@ class RunningContainers:
             # We only care about running containers after this point
             if not container.is_running:
                 continue
+
+            # Gather stop during backup containers
+            if container.stop_during_backup:
+                self.stop_during_backup_containers.append(container)
 
             # Detect running backup process container
             if container.is_backup_process_container:

--- a/src/restic_compose_backup/enums.py
+++ b/src/restic_compose_backup/enums.py
@@ -3,6 +3,7 @@
 LABEL_VOLUMES_ENABLED = 'stack-back.volumes'
 LABEL_VOLUMES_INCLUDE = 'stack-back.volumes.include'
 LABEL_VOLUMES_EXCLUDE = 'stack-back.volumes.exclude'
+LABEL_STOP_DURING_BACKUP = 'stack-back.volumes.stop-during-backup'
 
 LABEL_MYSQL_ENABLED = 'stack-back.mysql'
 LABEL_POSTGRES_ENABLED = 'stack-back.postgres'

--- a/src/restic_compose_backup/restic.py
+++ b/src/restic_compose_backup/restic.py
@@ -61,7 +61,8 @@ def snapshots(repository: str, last=True) -> Tuple[str, str]:
     """Returns the stdout and stderr info"""
     args = ["snapshots"]
     if last:
-        args.append('--last')
+        args.append("--latest")
+        args.append("1")
     return commands.run_capture_std(restic(repository, args))
 
 
@@ -72,7 +73,7 @@ def is_initialized(repository: str) -> bool:
     and other errors, but this method is reccomended by the restic
     community.
     """
-    return commands.run(restic(repository, ["snapshots", '--last'])) == 0
+    return commands.run(restic(repository, ["snapshots", "--latest", "1"])) == 0
 
 
 def forget(repository: str, daily: str, weekly: str, monthly: str, yearly: str):

--- a/src/restic_compose_backup/utils.py
+++ b/src/restic_compose_backup/utils.py
@@ -62,6 +62,28 @@ def remove_containers(containers: List['Container']):
             c.remove()
         except Exception as ex:
             logger.exception(ex)
+            
+def stop_containers(containers: List['Container']):
+    client = docker_client()
+    logger.info('Attempting to stop containers labeled to stop during backup')
+    for container in containers:
+        logger.info(' -> stopping %s', container.name)
+        try:
+            c = client.containers.get(container.name)
+            c.stop()
+        except Exception as ex:
+            logger.exception(ex)
+            
+def start_containers(containers: List['Container']):
+    client = docker_client()
+    logger.info('Attempting to restart containers that were stopped during backup')
+    for container in containers:
+        logger.info(' -> starting %s', container.name)
+        try:
+            c = client.containers.get(container.name)
+            c.start()
+        except Exception as ex:
+            logger.exception(ex)
 
 
 def is_true(value):


### PR DESCRIPTION
This pull request will be adding new features for the v1.1.0 release, including:
* new label `stack-back.volumes.stop-during-backup` to gracefully stop a container before backing up and restart it after
* arm64 support using qemu and docker buildx in the GitHub action that builds and releases the container image

There was also an opportunistic bug fixe that I noticed while implementing the above functionality:
* use `--latest 1` flag instead of the deprecated `--last` flag when fetching the most recent snapshot with the restic CLI