### PR TITLE
Remove MySQL/MariaDB timestamp comments and force consistent ordering

### DIFF
--- a/src/restic_compose_backup/containers_db.py
+++ b/src/restic_compose_backup/containers_db.py
@@ -51,7 +51,6 @@ class MariadbContainer(Container):
             "--single-transaction",
             "--order-by-primary",
             "--compact",
-            "--extended-insert",
             "--force"
         ]
 
@@ -122,7 +121,6 @@ class MysqlContainer(Container):
             "--single-transaction",
             "--order-by-primary",
             "--compact",
-            "--extended-insert",
             "--force"
         ]
 

--- a/src/restic_compose_backup/containers_db.py
+++ b/src/restic_compose_backup/containers_db.py
@@ -49,6 +49,10 @@ class MariadbContainer(Container):
             "--all-databases",
             "--no-tablespaces",
             "--single-transaction",
+            "--order-by-primary",
+            "--compact",
+            "--extended-insert",
+            "--force"
         ]
 
     def backup(self):
@@ -116,6 +120,10 @@ class MysqlContainer(Container):
             "--all-databases",
             "--no-tablespaces",
             "--single-transaction",
+            "--order-by-primary",
+            "--compact",
+            "--extended-insert",
+            "--force"
         ]
 
     def backup(self):


### PR DESCRIPTION
[Improve data deduplication by removing timestamp comments and forcing consistent ordering](https://forum.restic.net/t/the-dream-mysql-backups/737/8)