### PR TITLE
Add INCLUDE_ALL_VOLUMES env var and related tests

### DIFF
--- a/src/restic_compose_backup/config.py
+++ b/src/restic_compose_backup/config.py
@@ -15,6 +15,7 @@ class Config:
         self.swarm_mode = os.environ.get('SWARM_MODE') or False
         self.include_project_name = os.environ.get('INCLUDE_PROJECT_NAME') or False
         self.exclude_bind_mounts = os.environ.get('EXCLUDE_BIND_MOUNTS') or False
+        self.include_all_volumes = os.environ.get('INCLUDE_ALL_VOLUMES') or False
 
         # Log
         self.log_level = os.environ.get('LOG_LEVEL')

--- a/src/restic_compose_backup/containers.py
+++ b/src/restic_compose_backup/containers.py
@@ -146,7 +146,11 @@ class Container:
     @property
     def volume_backup_enabled(self) -> bool:
         """bool: If the ``stack-back.volumes`` label is set"""
-        return utils.is_true(self.get_label(enums.LABEL_VOLUMES_ENABLED))
+        label_value = self.get_label(enums.LABEL_VOLUMES_ENABLED)
+
+        return utils.is_true(label_value) or (
+            utils.is_true(config.include_all_volumes) and label_value is None
+        )
 
     @property
     def database_backup_enabled(self) -> bool:
@@ -171,7 +175,7 @@ class Container:
     def postgresql_backup_enabled(self) -> bool:
         """bool: If the ``stack-back.postgres`` label is set"""
         return utils.is_true(self.get_label(enums.LABEL_POSTGRES_ENABLED))
-    
+
     @property
     def stop_during_backup(self) -> bool:
         """bool: If the ``stack-back.volumes.stop-during-backup`` label is set"""


### PR DESCRIPTION
Hi! I added the `INCLUDE_ALL_VOLUMES` environment variable (guess what it does)

### The problem:
I've got ~30 different docker composes, which I didn't feel like individually adding the `stack-back.volumes = True` label. These are managed through Coolify, which makes it a significant hassle. Oh, and each time I add a new compose I'd have to remember to add the aforementioned label to each container (I don't trust myself).

### The solution(?
I figured I'm probably not the only one in this situation, so I added this flag. It will add all running containers to the backup process unless explicitly disabled, it works fine with the individual volume exclusion too (see tests below).

I think this will work quite fine with the `EXCLUDE_BIND_MOUNTS` flag for a quick and easy first time setup 😊.

Let me know what you think!