### PR TITLE
Unlock stale locks before forget and prune

### DIFF
--- a/src/restic_compose_backup/restic.py
+++ b/src/restic_compose_backup/restic.py
@@ -79,7 +79,7 @@ def is_initialized(repository: str) -> bool:
 def forget(repository: str, daily: str, weekly: str, monthly: str, yearly: str):
     commands.run(restic(repository, [
         'unlock'
-    ])
+    ]))
     return commands.run(restic(repository, [
         'forget',
         '--group-by',
@@ -98,7 +98,7 @@ def forget(repository: str, daily: str, weekly: str, monthly: str, yearly: str):
 def prune(repository: str):
     commands.run(restic(repository, [
         'unlock'
-    ])
+    ]))
     return commands.run(restic(repository, [
         'prune',
     ]))

--- a/src/restic_compose_backup/restic.py
+++ b/src/restic_compose_backup/restic.py
@@ -77,6 +77,9 @@ def is_initialized(repository: str) -> bool:
 
 
 def forget(repository: str, daily: str, weekly: str, monthly: str, yearly: str):
+    commands.run(restic(repository, [
+        'unlock'
+    ])
     return commands.run(restic(repository, [
         'forget',
         '--group-by',
@@ -93,6 +96,9 @@ def forget(repository: str, daily: str, weekly: str, monthly: str, yearly: str):
 
 
 def prune(repository: str):
+    commands.run(restic(repository, [
+        'unlock'
+    ])
     return commands.run(restic(repository, [
         'prune',
     ]))


### PR DESCRIPTION
Some cloud providers do not consistently clear locks after backing up data during `rcb backup`. This leads to the backup command failing to perform the forget and prune steps. Below is an example error message when this happens:

```
2025-04-24 22:09:43,287 - INFO: 2025-04-24 22:09:43,286 - INFO: Forget outdated snapshots
2025-04-24 22:09:50,793 - INFO: 2025-04-24 22:09:50,789 - ERROR: ---------- stdout ----------
2025-04-24 22:09:50,793 - INFO: 2025-04-24 22:09:50,789 - ERROR: repo already locked, waiting up to 0s for the lock
2025-04-24 22:09:50,794 - INFO: 2025-04-24 22:09:50,789 - ERROR: ----------------------------
2025-04-24 22:09:50,794 - INFO: 2025-04-24 22:09:50,789 - ERROR: ---------- stderr ----------
2025-04-24 22:09:50,795 - INFO: 2025-04-24 22:09:50,790 - ERROR: unable to create lock in backend: repository is already locked by PID 750 on ed0fccab98e5 by root (UID 0, GID 0)
2025-04-24 22:09:50,795 - INFO: 2025-04-24 22:09:50,790 - ERROR: lock was created at 2025-04-24 21:49:40 (20m10.719103776s ago)
2025-04-24 22:09:50,795 - INFO: 2025-04-24 22:09:50,790 - ERROR: storage ID 06ad2f22
2025-04-24 22:09:50,797 - INFO: 2025-04-24 22:09:50,790 - ERROR: the `unlock` command can be used to remove stale locks
2025-04-24 22:09:50,798 - INFO: 2025-04-24 22:09:50,790 - ERROR: ----------------------------
2025-04-24 22:09:50,798 - INFO: 2025-04-24 22:09:50,790 - INFO: Prune stale data freeing storage space
2025-04-24 22:09:59,849 - INFO: 2025-04-24 22:09:59,845 - ERROR: ---------- stdout ----------
2025-04-24 22:09:59,849 - INFO: 2025-04-24 22:09:59,845 - ERROR: repo already locked, waiting up to 0s for the lock
2025-04-24 22:09:59,849 - INFO: 2025-04-24 22:09:59,846 - ERROR: ----------------------------
2025-04-24 22:09:59,849 - INFO: 2025-04-24 22:09:59,846 - ERROR: ---------- stderr ----------
2025-04-24 22:09:59,850 - INFO: 2025-04-24 22:09:59,847 - ERROR: unable to create lock in backend: repository is already locked by PID 750 on ed0fccab98e5 by root (UID 0, GID 0)
2025-04-24 22:09:59,850 - INFO: 2025-04-24 22:09:59,847 - ERROR: lock was created at 2025-04-24 21:49:40 (20m19.774736335s ago)
2025-04-24 22:09:59,850 - INFO: 2025-04-24 22:09:59,847 - ERROR: storage ID 06ad2f22
2025-04-24 22:09:59,851 - INFO: 2025-04-24 22:09:59,848 - ERROR: the `unlock` command can be used to remove stale locks
2025-04-24 22:09:59,851 - INFO: 2025-04-24 22:09:59,848 - ERROR: ----------------------------
2025-04-24 22:09:59,851 - INFO: 2025-04-24 22:09:59,848 - ERROR: cleanup exit code: 11
2025-04-24 22:09:59,984 - INFO: Backup container exit code: 1
```

So far, restic has opted to [not automatically clear stale locks](https://github.com/restic/restic/issues/2736) and recommends using the `restic unlock` command instead. By default, only locks older than 30 minutes or when the pid is no longer found on the same machine are removed.

This PR adds the `restic unlock` command before forgetting and pruning to clean up any residual stale locks from the backup process that preceded it (the backup PID no longer exists).