### PR TITLE
Optional maintenance schedule

### DIFF
--- a/src/restic_compose_backup/cli.py
+++ b/src/restic_compose_backup/cli.py
@@ -256,17 +256,7 @@ def start_backup_process(config, containers):
 
     # Only run maintenance tasks if maintenance is not scheduled
     if not config.maintenance_schedule:
-        result = cleanup(config, container)
-        if result != 0:
-            logger.error('Cleanup exit code: %s', result)
-            exit(1)
-
-        logger.info("Checking the repository for errors")
-        check_with_cache = utils.is_true(config.check_with_cache)
-        result = restic.check(config.repository, with_cache=check_with_cache)
-        if result != 0:
-            logger.error('Check exit code: %s', result)
-            exit(1)
+        maintenance(config, containers)
 
     logger.info('Backup completed')
     
@@ -279,6 +269,7 @@ def maintenance(config, containers):
         logger.error('Cleanup exit code: %s', result)
         exit(1)
 
+    logger.info("Checking the repository for errors")
     check_with_cache = utils.is_true(config.check_with_cache)
     result = restic.check(config.repository, with_cache=check_with_cache)
     if result != 0:

--- a/src/restic_compose_backup/cli.py
+++ b/src/restic_compose_backup/cli.py
@@ -82,9 +82,9 @@ def status(config, containers):
     if containers.stale_backup_process_containers:
         utils.remove_containers(containers.stale_backup_process_containers)
 
-    # Check if repository is initialized with restic snapshots
+    logger.info("Contacting repository")
     if not restic.is_initialized(config.repository):
-        logger.info("Could not get repository info. Attempting to initialize it.")
+        logger.info("Repository is not initialized. Attempting to initialize it.")
         result = restic.init_repo(config.repository)
         if result == 0:
             logger.info("Successfully initialized repository: %s", config.repository)

--- a/src/restic_compose_backup/config.py
+++ b/src/restic_compose_backup/config.py
@@ -4,6 +4,7 @@ import os
 class Config:
     default_backup_command = "source /.env && rcb backup > /proc/1/fd/1"
     default_crontab_schedule = "0 2 * * *"
+    default_maintenance_command = "source /.env && rcb maintenance > /proc/1/fd/1"
 
     """Bag for config values"""
     def __init__(self, check=True):
@@ -13,6 +14,8 @@ class Config:
         self.check_with_cache = os.environ.get('CHECK_WITH_CACHE') or False
         self.cron_schedule = os.environ.get('CRON_SCHEDULE') or self.default_crontab_schedule
         self.cron_command = os.environ.get('CRON_COMMAND') or self.default_backup_command
+        self.maintenance_schedule = os.environ.get('MAINTENANCE_SCHEDULE') or ""
+        self.maintenance_command = os.environ.get('MAINTENANCE_COMMAND') or self.default_maintenance_command
         self.swarm_mode = os.environ.get('SWARM_MODE') or False
         self.include_project_name = os.environ.get('INCLUDE_PROJECT_NAME') or False
         self.exclude_bind_mounts = os.environ.get('EXCLUDE_BIND_MOUNTS') or False

--- a/src/restic_compose_backup/cron.py
+++ b/src/restic_compose_backup/cron.py
@@ -14,18 +14,29 @@ QUOTE_CHARS = ['"', "'"]
 
 def generate_crontab(config):
     """Generate a crontab entry for running backup job"""
-    command = config.cron_command.strip()
-    schedule = config.cron_schedule
+    backup_command = config.cron_command.strip()
+    backup_schedule = config.cron_schedule
 
-    if schedule:
-        schedule = schedule.strip()
-        schedule = strip_quotes(schedule)
-        if not validate_schedule(schedule):
-            schedule = config.default_crontab_schedule
+    if backup_schedule:
+        backup_schedule = backup_schedule.strip()
+        backup_schedule = strip_quotes(backup_schedule)
+        if not validate_schedule(backup_schedule):
+            backup_schedule = config.default_crontab_schedule
     else:
-        schedule = config.default_crontab_schedule
+        backup_schedule = config.default_crontab_schedule
 
-    return f'{schedule} {command}\n'
+    crontab = f'{backup_schedule} {backup_command}\n'
+    
+    maintenance_command = config.maintenance_command.strip()
+    maintenance_schedule = config.maintenance_schedule
+    
+    if maintenance_schedule:
+        maintenance_schedule = maintenance_schedule.strip()
+        maintenance_schedule = strip_quotes(maintenance_schedule)
+        if validate_schedule(maintenance_schedule):
+            crontab += f'{maintenance_schedule} {maintenance_command}\n'
+
+    return crontab
 
 
 def validate_schedule(schedule: str):

--- a/src/restic_compose_backup/restic.py
+++ b/src/restic_compose_backup/restic.py
@@ -77,9 +77,6 @@ def is_initialized(repository: str) -> bool:
 
 
 def forget(repository: str, daily: str, weekly: str, monthly: str, yearly: str):
-    commands.run(restic(repository, [
-        'unlock'
-    ]))
     return commands.run(restic(repository, [
         'forget',
         '--group-by',
@@ -96,9 +93,6 @@ def forget(repository: str, daily: str, weekly: str, monthly: str, yearly: str):
 
 
 def prune(repository: str):
-    commands.run(restic(repository, [
-        'unlock'
-    ]))
     return commands.run(restic(repository, [
         'prune',
     ]))

--- a/src/restic_compose_backup/restic.py
+++ b/src/restic_compose_backup/restic.py
@@ -69,11 +69,16 @@ def snapshots(repository: str, last=True) -> Tuple[str, str]:
 def is_initialized(repository: str) -> bool:
     """
     Checks if a repository is initialized using snapshots command.
-    Note that this cannot separate between uninitalized repo
-    and other errors, but this method is reccomended by the restic
-    community.
+    https://restic.readthedocs.io/en/latest/075_scripting.html#check-if-a-repository-is-already-initialized
     """
-    return commands.run(restic(repository, ["snapshots", "--latest", "1"])) == 0
+    response = commands.run(restic(repository, ["cat", "config"]))
+    if response == 0:
+        return True
+    elif response == 10:
+        return False
+    else:
+        logger.error("Error checking if repository is initialized")
+        exit(1)
 
 
 def forget(repository: str, daily: str, weekly: str, monthly: str, yearly: str):

--- a/src/restic_compose_backup/restic.py
+++ b/src/restic_compose_backup/restic.py
@@ -68,7 +68,7 @@ def snapshots(repository: str, last=True) -> Tuple[str, str]:
 
 def is_initialized(repository: str) -> bool:
     """
-    Checks if a repository is initialized using snapshots command.
+    Checks if a repository is initialized with restic cat config.
     https://restic.readthedocs.io/en/latest/075_scripting.html#check-if-a-repository-is-already-initialized
     """
     response = commands.run(restic(repository, ["cat", "config"]))
@@ -77,7 +77,7 @@ def is_initialized(repository: str) -> bool:
     elif response == 10:
         return False
     else:
-        logger.error("Error checking if repository is initialized")
+        logger.error("Error while checking if repository is initialized")
         exit(1)
 
 


### PR DESCRIPTION
Allow users to schedule forget/prune/check actions separately from backups to reduce the number of read operations run against remote cloud storage like S3 and B2.

When the new environment variable `MAINTENANCE_SCHEDULE` is not set, the default behavior remains the same as before and maintenance actions will happen following every successful backup.