### PR TITLE
Detect databases to enable auto backups

### DIFF
--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -215,15 +215,25 @@ connecting to the Docker host. Combined with ``DOCKER_TLS_VERIFY``
 this can be used to talk to docker through TLS in cases
 were we cannot map in the docker socket.
 
-INCLUDE_ALL_VOLUMES
+AUTO_BACKUP_ALL
 ~~~~~~~~~~~~~~~~~~~
 
-If defined, all volumes will be included in the backup.
-This is useful when you want to back up all volumes
-in a project without having to add labels to each service.
+If defined, all volumes and databases in the project will be 
+included in the backup. This removes the need to add labels to 
+each service when you want to back up everything.
 
-Volumes can be excluded by adding the ``stack-back.volumes.exclude``
-label to the service.
+Database detection is based on the default images for mariadb, mysql 
+and postgres. When a database is detected, the volume associated with 
+the database data is automatically excluded from the backup.
+
+Volumes can be excluded by adding the ``stack-back.volumes.exclude: <volume_name>``
+or ``stack-back.volumes: False`` label to the service.
+
+Databases can be excluded by adding the
+``stack-back.<db_type>: False`` label to the service along with 
+``stack-back.volumes: False``. Forgetting to also exclude the 
+volumes may result in a backup of the database files volume instead 
+of the database itself.
 
 INCLUDE_PROJECT_NAME
 ~~~~~~~~~~~~~~~~~~~~

--- a/src/restic_compose_backup/config.py
+++ b/src/restic_compose_backup/config.py
@@ -1,5 +1,7 @@
+import logging
 import os
 
+logger = logging.getLogger(__name__)
 
 class Config:
     default_backup_command = "source /.env && rcb backup > /proc/1/fd/1"
@@ -20,6 +22,9 @@ class Config:
         self.include_project_name = os.environ.get('INCLUDE_PROJECT_NAME') or False
         self.exclude_bind_mounts = os.environ.get('EXCLUDE_BIND_MOUNTS') or False
         self.include_all_volumes = os.environ.get('INCLUDE_ALL_VOLUMES') or False
+        if self.include_all_volumes:
+            logger.warning("INCLUDE_ALL_VOLUMES will be deprecated in the future in favor of AUTO_BACKUP_ALL. Please update your environment variables.")
+        self.auto_backup_all = os.environ.get('AUTO_BACKUP_ALL') or self.include_all_volumes
 
         # Log
         self.log_level = os.environ.get('LOG_LEVEL')

--- a/src/restic_compose_backup/containers.py
+++ b/src/restic_compose_backup/containers.py
@@ -164,17 +164,26 @@ class Container:
     @property
     def mysql_backup_enabled(self) -> bool:
         """bool: If the ``stack-back.mysql`` label is set"""
-        return utils.is_true(self.get_label(enums.LABEL_MYSQL_ENABLED))
+        explicity_enabled = utils.is_true(self.get_label(enums.LABEL_MYSQL_ENABLED))
+        explicity_disabled = utils.is_false(self.get_label(enums.LABEL_MYSQL_ENABLED))
+        automatically_enabled = utils.is_true(config.include_all_volumes) and self.image.startswith('mysql:')
+        return explicity_enabled or (automatically_enabled and not explicity_disabled)
 
     @property
     def mariadb_backup_enabled(self) -> bool:
         """bool: If the ``stack-back.mariadb`` label is set"""
-        return utils.is_true(self.get_label(enums.LABEL_MARIADB_ENABLED))
+        explicity_enabled = utils.is_true(self.get_label(enums.LABEL_MARIADB_ENABLED))
+        explicity_disabled = utils.is_false(self.get_label(enums.LABEL_MARIADB_ENABLED))
+        automatically_enabled = utils.is_true(config.include_all_volumes) and self.image.startswith('mariadb:')
+        return explicity_enabled or (automatically_enabled and not explicity_disabled)
 
     @property
     def postgresql_backup_enabled(self) -> bool:
         """bool: If the ``stack-back.postgres`` label is set"""
-        return utils.is_true(self.get_label(enums.LABEL_POSTGRES_ENABLED))
+        explicity_enabled = utils.is_true(self.get_label(enums.LABEL_POSTGRES_ENABLED))
+        explicity_disabled = utils.is_false(self.get_label(enums.LABEL_POSTGRES_ENABLED))
+        automatically_enabled = utils.is_true(config.include_all_volumes) and self.image.startswith('postgres:')
+        return explicity_enabled or (automatically_enabled and not explicity_disabled)
 
     @property
     def stop_during_backup(self) -> bool:

--- a/src/restic_compose_backup/containers.py
+++ b/src/restic_compose_backup/containers.py
@@ -211,6 +211,7 @@ class Container:
     def filter_mounts(self):
         """Get all mounts for this container matching include/exclude filters"""
         filtered = []
+        database_mounts = ["/var/lib/mysql", "/var/lib/postgresql/data"]
 
         # If exclude_bind_mounts is true, only volume mounts are kept in the list of mounts
         exclude_bind_mounts = utils.is_true(config.exclude_bind_mounts)
@@ -237,7 +238,10 @@ class Container:
                 else:
                     filtered.append(mount)
         else:
-            return mounts
+            for mount in mounts:
+                if self.database_backup_enabled and mount.destination in database_mounts:
+                    continue
+                filtered.append(mount)
 
         return filtered
 

--- a/src/restic_compose_backup/containers.py
+++ b/src/restic_compose_backup/containers.py
@@ -149,7 +149,7 @@ class Container:
         label_value = self.get_label(enums.LABEL_VOLUMES_ENABLED)
 
         return utils.is_true(label_value) or (
-            utils.is_true(config.include_all_volumes) and label_value is None
+            utils.is_true(config.auto_backup_all) and label_value is None
         )
 
     @property
@@ -166,7 +166,7 @@ class Container:
         """bool: If the ``stack-back.mysql`` label is set"""
         explicity_enabled = utils.is_true(self.get_label(enums.LABEL_MYSQL_ENABLED))
         explicity_disabled = utils.is_false(self.get_label(enums.LABEL_MYSQL_ENABLED))
-        automatically_enabled = utils.is_true(config.include_all_volumes) and self.image.startswith('mysql:')
+        automatically_enabled = utils.is_true(config.auto_backup_all) and self.image.startswith('mysql:')
         return explicity_enabled or (automatically_enabled and not explicity_disabled)
 
     @property
@@ -174,7 +174,7 @@ class Container:
         """bool: If the ``stack-back.mariadb`` label is set"""
         explicity_enabled = utils.is_true(self.get_label(enums.LABEL_MARIADB_ENABLED))
         explicity_disabled = utils.is_false(self.get_label(enums.LABEL_MARIADB_ENABLED))
-        automatically_enabled = utils.is_true(config.include_all_volumes) and self.image.startswith('mariadb:')
+        automatically_enabled = utils.is_true(config.auto_backup_all) and self.image.startswith('mariadb:')
         return explicity_enabled or (automatically_enabled and not explicity_disabled)
 
     @property
@@ -182,7 +182,7 @@ class Container:
         """bool: If the ``stack-back.postgres`` label is set"""
         explicity_enabled = utils.is_true(self.get_label(enums.LABEL_POSTGRES_ENABLED))
         explicity_disabled = utils.is_false(self.get_label(enums.LABEL_POSTGRES_ENABLED))
-        automatically_enabled = utils.is_true(config.include_all_volumes) and self.image.startswith('postgres:')
+        automatically_enabled = utils.is_true(config.auto_backup_all) and self.image.startswith('postgres:')
         return explicity_enabled or (automatically_enabled and not explicity_disabled)
 
     @property

--- a/src/restic_compose_backup/utils.py
+++ b/src/restic_compose_backup/utils.py
@@ -9,7 +9,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-TRUE_VALUES = ['1', 'true', 'True', True, 1]
+TRUE_VALUES = ['1', 'true', 'True', 'TRUE', True, 1]
+FALSE_VALUES = ['0', 'false', 'False', 'FALSE', False, 0]
 
 
 def docker_client():
@@ -91,6 +92,13 @@ def is_true(value):
     Evaluates the truthfullness of a bool value in container labels
     """
     return value in TRUE_VALUES
+
+
+def is_false(value):
+    """
+    Evaluates the falseness of a bool value in container labels
+    """
+    return value in FALSE_VALUES
 
 
 def strip_root(path):

--- a/src/tests/fixtures.py
+++ b/src/tests/fixtures.py
@@ -21,6 +21,7 @@ def containers(project="default", containers=[]):
                 'containers: [
                     'id': 'something'
                     'service': 'service_name',
+                    'image': 'image:tag',
                     'mounts: [{
                         'Source': '/home/user/stuff',
                         'Destination': '/srv/stuff',
@@ -35,7 +36,7 @@ def containers(project="default", containers=[]):
             'Id': container.get('id', generate_sha256()),
             'Name': container.get('service') + '_' + ''.join(random.choice(string.ascii_lowercase) for i in range(16)),
             'Config': {
-                'Image': 'stack-back_backup',
+                'Image': container.get('image', 'image:latest'),
                 'Labels': {
                     'com.docker.compose.oneoff': 'False',
                     'com.docker.compose.project': project,

--- a/src/tests/tests.py
+++ b/src/tests/tests.py
@@ -123,6 +123,25 @@ class ResticBackupTests(BaseTestCase):
         self.assertTrue(mysql_service.mysql_backup_enabled)
         self.assertEqual(len(mounts), 0)
 
+    def test_no_volumes_for_backup(self):
+        containers = self.createContainers()
+        containers += [
+            {
+                'service': 'web',
+                'labels': {
+                    'stack-back.volumes': True,
+                },
+            },
+        ]
+        with mock.patch(list_containers_func, fixtures.containers(containers=containers)):
+            cnt = RunningContainers()
+            self.assertTrue(len(cnt.containers_for_backup()) == 1)
+        web_service = cnt.get_service('web')
+        self.assertNotEqual(web_service, None, msg="Web service not found")
+        mounts = web_service.filter_mounts()
+        print(mounts)
+        self.assertEqual(len(mounts), 0)
+
     def test_databases_for_backup(self):
         containers = self.createContainers()
         containers += [
@@ -416,7 +435,7 @@ class IncludeAllVolumesTests(BaseTestCase):
 
         postgres_service = cnt.get_service("postgres")
         self.assertNotEqual(postgres_service, None, msg="Postgres service not found")
-        self.assertTrue(postgres_service.postgres_backup_enabled)
+        self.assertTrue(postgres_service.postgresql_backup_enabled)
         mounts = postgres_service.filter_mounts()
         print(mounts)
         self.assertEqual(len(mounts), 0)

--- a/src/tests/tests.py
+++ b/src/tests/tests.py
@@ -590,6 +590,7 @@ class IncludeAllVolumesTests(BaseTestCase):
                 "service": "mysql",
                 'labels': {
                     'stack-back.mysql': False,
+                    'stack-back.volumes': False,
                 },
                 "mounts": [
                     {

--- a/src/tests/tests.py
+++ b/src/tests/tests.py
@@ -336,14 +336,14 @@ class ResticBackupTests(BaseTestCase):
 class IncludeAllVolumesTests(BaseTestCase):
     @classmethod
     def setUpClass(cls):
-        config.config.include_all_volumes = "true"
+        config.config.auto_backup_all = "true"
 
     @classmethod
     def tearDownClass(cls):
         config.config = config.Config()
 
     def test_all_volumes(self):
-        """Test that the INCLUDE_ALL_VOLUMES flag works"""
+        """Test that the AUTO_BACKUP_ALL flag works"""
         containers = self.createContainers()
         containers += [
             {
@@ -377,7 +377,7 @@ class IncludeAllVolumesTests(BaseTestCase):
         self.assertEqual(mounts[1].source, "/srv/files/stuff")
 
     def test_all_databases(self):
-        """Test that the INCLUDE_ALL_VOLUMES flag intelligently handles databases based on image"""
+        """Test that the AUTO_BACKUP_ALL flag intelligently handles databases based on image"""
         containers = self.createContainers()
         containers += [
             {

--- a/src/tests/tests.py
+++ b/src/tests/tests.py
@@ -402,24 +402,24 @@ class IncludeAllVolumesTests(BaseTestCase):
 
         mysql_service = cnt.get_service("mysql")
         self.assertNotEqual(mysql_service, None, msg="MySQL service not found")
+        self.assertTrue(mysql_service.mysql_backup_enabled)
         mounts = mysql_service.filter_mounts()
         print(mounts)
         self.assertEqual(len(mounts), 0)
-        self.assertTrue(mysql_service.mysql_backup_enabled)
 
         mariadb_service = cnt.get_service("mariadb")
         self.assertNotEqual(mariadb_service, None, msg="MariaDB service not found")
+        self.assertTrue(mariadb_service.mariadb_backup_enabled)
         mounts = mariadb_service.filter_mounts()
         print(mounts)
         self.assertEqual(len(mounts), 0)
-        self.assertTrue(mariadb_service.mariadb_backup_enabled)
 
         postgres_service = cnt.get_service("postgres")
         self.assertNotEqual(postgres_service, None, msg="Postgres service not found")
+        self.assertTrue(postgres_service.postgres_backup_enabled)
         mounts = postgres_service.filter_mounts()
         print(mounts)
         self.assertEqual(len(mounts), 0)
-        self.assertTrue(postgres_service.postgres_backup_enabled)
         
     def test_redundant_volume_label(self):
         """Test that a container has a redundant volume label should be backed up"""
@@ -485,13 +485,13 @@ class IncludeAllVolumesTests(BaseTestCase):
 
         mysql_service = cnt.get_service("mysql")
         self.assertNotEqual(mysql_service, None, msg="MySQL service not found")
+        self.assertTrue(mysql_service.mysql_backup_enabled)
         mounts = mysql_service.filter_mounts()
         print(mounts)
         self.assertEqual(len(mounts), 0)
-        self.assertTrue(mysql_service.mysql_backup_enabled)
 
-    def test_explicit_exclude(self):
-        """Test that a container can be excluded from the backup"""
+    def test_explicit_volumes_exclude(self):
+        """Test that a container's volumes can be excluded from the backup"""
 
         containers = self.createContainers()
         containers += [
@@ -588,7 +588,7 @@ class IncludeAllVolumesTests(BaseTestCase):
 
         mysql_service = cnt.get_service("mysql")
         self.assertNotEqual(mysql_service, None, msg="MySQL service not found")
+        self.assertFalse(mysql_service.mysql_backup_enabled)
         mounts = mysql_service.filter_mounts()
         print(mounts)
         self.assertEqual(len(mounts), 0)
-        self.assertFalse(mysql_service.mysql_backup_enabled)


### PR DESCRIPTION
This PR adds the following features:

## replace `INCLUDE_ALL_VOLUMES` with `AUTO_BACKUP_ALL`

stack-back now has one environment variable to back up all volumes and databases. Due to the new inclusion of databases, the previous auto-detection variable will be soft-deprecated and replaced with `AUTO_BACKUP_ALL` for less confusion. To maintain backward compatibility, `INCLUDE_ALL_VOLUMES` will continue to function in the same way as `AUTO_BACKUP_ALL` if it is defined instead.

## auto-detect database images

To automate the detection of databases, stack-back examines the image of running containers to check if it is an official database image ([mysql](https://hub.docker.com/_/mysql), [mariadb](https://hub.docker.com/_/mariadb), or [postgres](https://hub.docker.com/_/postgres)).

When database images are auto-detected and added to the backup configuration, their default data volume mount is excluded from volume backups to prevent duplicate backups (volume *__and__* database dump). Excluded mount destinations are `/var/lib/mysql` for MySQL and MariaDB and `/var/lib/postgres/data` for Postgres.

## tests and documentation

A number of tests were added to guard against edge cases with the new detection methods. Documentation includes the information above.
