### PR TITLE
Added formatter

### DIFF
--- a/.github/workflows/pr-verify.yaml
+++ b/.github/workflows/pr-verify.yaml
@@ -32,6 +32,7 @@ jobs:
   code-quality:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: astral-sh/ruff-action@v3
         with:
           args: "format --check --diff"

--- a/.github/workflows/pr-verify.yaml
+++ b/.github/workflows/pr-verify.yaml
@@ -35,7 +35,8 @@ jobs:
       - uses: astral-sh/ruff-action@v3
         with:
           args: "format --check --diff"
-          version-file: src/pyproject.toml # tooling generally assumes the pyproject will be at the root of the repo
+          src: ./src
+          version-file: ./src/pyproject.toml
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-verify.yaml
+++ b/.github/workflows/pr-verify.yaml
@@ -35,7 +35,7 @@ jobs:
       - uses: astral-sh/ruff-action@v3
         with:
           args: "format --check --diff"
-          
+          version-file: src/pyproject.toml # tooling generally assumes the pyproject will be at the root of the repo
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-verify.yaml
+++ b/.github/workflows/pr-verify.yaml
@@ -29,6 +29,13 @@ jobs:
           uv sync --locked --directory src/
           uv run --directory src/ pytest
 
+  code-quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check --diff"
+          
   build:
     runs-on: ubuntu-latest
     steps:

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -12,6 +12,7 @@ dev = [
     "black>=25.1.0",
     "pre-commit>=4.2.0",
     "pytest>=7.4.0",
+    "ruff>=0.12.3",
 ]
 
 [tool.pytest.ini_options]

--- a/src/restic_compose_backup/alerts/__init__.py
+++ b/src/restic_compose_backup/alerts/__init__.py
@@ -5,24 +5,26 @@ from restic_compose_backup.alerts.discord import DiscordWebhookAlert
 
 logger = logging.getLogger(__name__)
 
-ALERT_INFO = 'INFO',
-ALERT_ERROR = 'ERROR'
+ALERT_INFO = ("INFO",)
+ALERT_ERROR = "ERROR"
 ALERT_TYPES = [ALERT_INFO, ALERT_ERROR]
 BACKENDS = [SMTPAlert, DiscordWebhookAlert]
 
 
-def send(subject: str = None, body: str = None, alert_type: str = 'INFO'):
+def send(subject: str = None, body: str = None, alert_type: str = "INFO"):
     """Send alert to all configured backends"""
     alert_classes = configured_alert_types()
     for instance in alert_classes:
-        logger.info('Configured: %s', instance.name)
+        logger.info("Configured: %s", instance.name)
         try:
             instance.send(
-                subject=f'[{alert_type}] {subject}',
+                subject=f"[{alert_type}] {subject}",
                 body=body,
             )
         except Exception as ex:
-            logger.error("Exception raised when sending alert [%s]: %s", instance.name, ex)
+            logger.error(
+                "Exception raised when sending alert [%s]: %s", instance.name, ex
+            )
             logger.exception(ex)
 
     if len(alert_classes) == 0:
@@ -31,12 +33,14 @@ def send(subject: str = None, body: str = None, alert_type: str = 'INFO'):
 
 def configured_alert_types():
     """Returns a list of configured alert class instances"""
-    logger.debug('Getting alert backends')
+    logger.debug("Getting alert backends")
     entires = []
 
     for cls in BACKENDS:
         instance = cls.create_from_env()
-        logger.debug("Alert backend '%s' configured: %s", cls.name, instance is not None)
+        logger.debug(
+            "Alert backend '%s' configured: %s", cls.name, instance is not None
+        )
         if instance:
             entires.append(instance)
 

--- a/src/restic_compose_backup/alerts/base.py
+++ b/src/restic_compose_backup/alerts/base.py
@@ -1,5 +1,3 @@
-
-
 class BaseAlert:
     name = None
 

--- a/src/restic_compose_backup/alerts/discord.py
+++ b/src/restic_compose_backup/alerts/discord.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 class DiscordWebhookAlert(BaseAlert):
-    name = 'discord_webhook'
+    name = "discord_webhook"
     success_codes = [200]
 
     def __init__(self, webhook_url):
@@ -16,7 +16,7 @@ class DiscordWebhookAlert(BaseAlert):
 
     @classmethod
     def create_from_env(cls):
-        instance = cls(os.environ.get('DISCORD_WEBHOOK'))
+        instance = cls(os.environ.get("DISCORD_WEBHOOK"))
 
         if instance.properly_configured:
             return instance
@@ -34,15 +34,17 @@ class DiscordWebhookAlert(BaseAlert):
         #       The max description size is 2048
         #       Total embed size limit is 6000 characters (per embed)
         data = {
-            'embeds': [
+            "embeds": [
                 {
-                    'title': subject[-256:],
-                    'description': body[-2048:] if body else "",
+                    "title": subject[-256:],
+                    "description": body[-2048:] if body else "",
                 },
             ]
         }
-        response = requests.post(self.url, params={'wait': True}, json=data)
+        response = requests.post(self.url, params={"wait": True}, json=data)
         if response.status_code not in self.success_codes:
-            logger.error("Discord webhook failed: %s: %s", response.status_code, response.content)
+            logger.error(
+                "Discord webhook failed: %s: %s", response.status_code, response.content
+            )
         else:
-            logger.info('Discord webhook successful')
+            logger.info("Discord webhook successful")

--- a/src/restic_compose_backup/alerts/smtp.py
+++ b/src/restic_compose_backup/alerts/smtp.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class SMTPAlert(BaseAlert):
-    name = 'smtp'
+    name = "smtp"
 
     def __init__(self, host, port, user, password, to):
         self.host = host
@@ -21,11 +21,11 @@ class SMTPAlert(BaseAlert):
     @classmethod
     def create_from_env(cls):
         instance = cls(
-            os.environ.get('EMAIL_HOST'),
-            os.environ.get('EMAIL_PORT'),
-            os.environ.get('EMAIL_HOST_USER'),
-            os.environ.get('EMAIL_HOST_PASSWORD'),
-            (os.environ.get('EMAIL_SEND_TO') or "").split(','),
+            os.environ.get("EMAIL_HOST"),
+            os.environ.get("EMAIL_PORT"),
+            os.environ.get("EMAIL_HOST_USER"),
+            os.environ.get("EMAIL_HOST_PASSWORD"),
+            (os.environ.get("EMAIL_SEND_TO") or "").split(","),
         )
         if instance.properly_configured:
             return instance
@@ -36,11 +36,11 @@ class SMTPAlert(BaseAlert):
     def properly_configured(self) -> bool:
         return self.host and self.port and self.user and len(self.to) > 0
 
-    def send(self, subject: str = None, body: str = None, alert_type: str = 'INFO'):
+    def send(self, subject: str = None, body: str = None, alert_type: str = "INFO"):
         msg = MIMEText(body)
-        msg['Subject'] = f"[{alert_type}] {subject}"
-        msg['From'] = self.user
-        msg['To'] = ', '.join(self.to)
+        msg["Subject"] = f"[{alert_type}] {subject}"
+        msg["From"] = self.user
+        msg["To"] = ", ".join(self.to)
 
         try:
             logger.info("Connecting to %s port %s", self.host, self.port)
@@ -52,7 +52,9 @@ class SMTPAlert(BaseAlert):
                 try:
                     server.starttls()
                 except smtplib.SMTPHeloError:
-                    logger.error("The server didn't reply properly to the HELO greeting. Email not sent.")
+                    logger.error(
+                        "The server didn't reply properly to the HELO greeting. Email not sent."
+                    )
                     return
                 except smtplib.SMTPNotSupportedError:
                     logger.error("STARTTLS not supported on server. Email not sent.")
@@ -60,7 +62,7 @@ class SMTPAlert(BaseAlert):
             server.ehlo()
             server.login(self.user, self.password)
             server.sendmail(self.user, self.to, msg.as_string())
-            logger.info('Email sent')
+            logger.info("Email sent")
         except Exception as ex:
             logger.exception(ex)
         finally:

--- a/src/restic_compose_backup/backup_runner.py
+++ b/src/restic_compose_backup/backup_runner.py
@@ -6,8 +6,14 @@ from restic_compose_backup import utils
 logger = logging.getLogger(__name__)
 
 
-def run(image: str = None, command: str = None, volumes: dict = None,
-        environment: dict = None, labels: dict = None, source_container_id: str = None):
+def run(
+    image: str = None,
+    command: str = None,
+    volumes: dict = None,
+    environment: dict = None,
+    labels: dict = None,
+    source_container_id: str = None,
+):
     logger.info("Starting backup container")
     client = utils.docker_client()
 
@@ -17,9 +23,9 @@ def run(image: str = None, command: str = None, volumes: dict = None,
         labels=labels,
         # auto_remove=True,  # We remove the container further down
         detach=True,
-        environment=environment + ['BACKUP_PROCESS_CONTAINER=true'],
+        environment=environment + ["BACKUP_PROCESS_CONTAINER=true"],
         volumes=volumes,
-        network_mode=f'container:{source_container_id}',  # Reuse original container's network stack.
+        network_mode=f"container:{source_container_id}",  # Reuse original container's network stack.
         working_dir=os.getcwd(),
         tty=True,
     )
@@ -40,7 +46,7 @@ def run(image: str = None, command: str = None, volumes: dict = None,
                         line += data.decode()
                     elif isinstance(data, str):
                         line += data
-                    if line.endswith('\n'):
+                    if line.endswith("\n"):
                         break
                 except StopIteration:
                     break
@@ -49,15 +55,15 @@ def run(image: str = None, command: str = None, volumes: dict = None,
             else:
                 break
 
-    with open('backup.log', 'w') as fd:
+    with open("backup.log", "w") as fd:
         for line in readlines(log_generator):
             fd.write(line)
-            fd.write('\n')
+            fd.write("\n")
             print(line)
 
     container.wait()
     container.reload()
-    logger.debug("Container ExitCode %s", container.attrs['State']['ExitCode'])
+    logger.debug("Container ExitCode %s", container.attrs["State"]["ExitCode"])
     container.remove()
 
-    return container.attrs['State']['ExitCode']
+    return container.attrs["State"]["ExitCode"]

--- a/src/restic_compose_backup/cli.py
+++ b/src/restic_compose_backup/cli.py
@@ -24,31 +24,32 @@ def main():
 
     # Ensure log level is propagated to parent container if overridden
     if args.log_level:
-        containers.this_container.set_config_env('LOG_LEVEL', args.log_level)
+        containers.this_container.set_config_env("LOG_LEVEL", args.log_level)
 
-    if args.action == 'status':
+    if args.action == "status":
         status(config, containers)
 
-    elif args.action == 'snapshots':
+    elif args.action == "snapshots":
         snapshots(config, containers)
 
-    elif args.action == 'backup':
+    elif args.action == "backup":
         backup(config, containers)
 
-    elif args.action == 'start-backup-process':
+    elif args.action == "start-backup-process":
         start_backup_process(config, containers)
-        
-    elif args.action == 'maintenance':
+
+    elif args.action == "maintenance":
         maintenance(config, containers)
 
-    elif args.action == 'cleanup':
+    elif args.action == "cleanup":
         cleanup(config, containers)
 
-    elif args.action == 'alert':
+    elif args.action == "alert":
         alert(config, containers)
 
-    elif args.action == 'version':
+    elif args.action == "version":
         import restic_compose_backup
+
         print(restic_compose_backup.__version__)
 
     elif args.action == "crontab":
@@ -62,9 +63,9 @@ def main():
         nodes = utils.get_swarm_nodes()
         print("Swarm nodes:")
         for node in nodes:
-            addr = node.attrs['Status']['Addr']
-            state = node.attrs['Status']['State']
-            print(' - {} {} {}'.format(node.id, addr, state))
+            addr = node.attrs["Status"]["Addr"]
+            state = node.attrs["Status"]["State"]
+            print(" - {} {} {}".format(node.id, addr, state))
 
 
 def status(config, containers):
@@ -72,9 +73,17 @@ def status(config, containers):
     logger.info("Status for compose project '%s'", containers.project_name)
     logger.info("Repository: '%s'", config.repository)
     logger.info("Backup currently running?: %s", containers.backup_process_running)
-    logger.info("Include project name in backup path?: %s", utils.is_true(config.include_project_name))
-    logger.debug("Exclude bind mounts from backups?: %s", utils.is_true(config.exclude_bind_mounts))
-    logger.debug(f"Use cache for integrity check?: {utils.is_true(config.check_with_cache)}")
+    logger.info(
+        "Include project name in backup path?: %s",
+        utils.is_true(config.include_project_name),
+    )
+    logger.debug(
+        "Exclude bind mounts from backups?: %s",
+        utils.is_true(config.exclude_bind_mounts),
+    )
+    logger.debug(
+        f"Use cache for integrity check?: {utils.is_true(config.check_with_cache)}"
+    )
     logger.info("Checking docker availability")
 
     utils.list_containers()
@@ -96,29 +105,32 @@ def status(config, containers):
     # Start making snapshots
     backup_containers = containers.containers_for_backup()
     for container in backup_containers:
-        logger.info('service: %s', container.service_name)
+        logger.info("service: %s", container.service_name)
 
         if container.volume_backup_enabled:
             logger.info(f" - stop during backup: {container.stop_during_backup}")
             for mount in container.filter_mounts():
                 logger.info(
-                    ' - volume: %s -> %s',
+                    " - volume: %s -> %s",
                     mount.source,
-                    container.get_volume_backup_destination(mount, '/volumes'),
+                    container.get_volume_backup_destination(mount, "/volumes"),
                 )
 
         if container.database_backup_enabled:
             instance = container.instance
             ping = instance.ping()
             logger.info(
-                ' - %s (is_ready=%s) -> %s',
+                " - %s (is_ready=%s) -> %s",
                 instance.container_type,
                 ping == 0,
                 instance.backup_destination_path(),
             )
             if ping != 0:
-                logger.error("Database '%s' in service %s cannot be reached",
-                             instance.container_type, container.service_name)
+                logger.error(
+                    "Database '%s' in service %s cannot be reached",
+                    instance.container_type,
+                    container.service_name,
+                )
 
     if len(backup_containers) == 0:
         logger.info("No containers in the project has 'stack-back.*' label")
@@ -137,7 +149,7 @@ def backup(config, containers):
                 f"Id: {containers.backup_process_container.id}\n"
                 f"Name: {containers.backup_process_container.name}\n"
             ),
-            alert_type='ERROR',
+            alert_type="ERROR",
         )
         raise RuntimeError("Backup process already running")
 
@@ -145,19 +157,21 @@ def backup(config, containers):
     volumes = containers.this_container.volumes
 
     # Map volumes from other containers we are backing up
-    mounts = containers.generate_backup_mounts('/volumes')
+    mounts = containers.generate_backup_mounts("/volumes")
     volumes.update(mounts)
 
-    logger.debug('Starting backup container with image %s', containers.this_container.image)
+    logger.debug(
+        "Starting backup container with image %s", containers.this_container.image
+    )
     try:
         result = backup_runner.run(
             image=containers.this_container.image,
-            command='rcb start-backup-process',
+            command="rcb start-backup-process",
             volumes=volumes,
             environment=containers.this_container.environment,
             source_container_id=containers.this_container.id,
             labels={
-                containers.backup_process_label: 'True',
+                containers.backup_process_label: "True",
                 "com.docker.compose.project": containers.project_name,
             },
         )
@@ -166,24 +180,24 @@ def backup(config, containers):
         alerts.send(
             subject="Exception during backup",
             body=str(ex),
-            alert_type='ERROR',
+            alert_type="ERROR",
         )
         return
 
-    logger.info('Backup container exit code: %s', result)
+    logger.info("Backup container exit code: %s", result)
 
     # Alert the user if something went wrong
     if result != 0:
         alerts.send(
             subject="Backup process exited with non-zero code",
-            body=open('backup.log').read(),
-            alert_type='ERROR',
+            body=open("backup.log").read(),
+            alert_type="ERROR",
         )
 
 
 def start_backup_process(config, containers):
     """The actual backup process running inside the spawned container"""
-    if not utils.is_true(os.environ.get('BACKUP_PROCESS_CONTAINER')):
+    if not utils.is_true(os.environ.get("BACKUP_PROCESS_CONTAINER")):
         logger.error(
             "Cannot run backup process in this container. Use backup command instead. "
             "This will spawn a new container with the necessary mounts."
@@ -193,7 +207,7 @@ def start_backup_process(config, containers):
             body=(
                 "Cannot run backup process in this container. Use backup command instead. "
                 "This will spawn a new container with the necessary mounts."
-            )
+            ),
         )
         exit(1)
 
@@ -202,7 +216,7 @@ def start_backup_process(config, containers):
 
     # Did we actually get any volumes mounted?
     try:
-        has_volumes = os.stat('/volumes') is not None
+        has_volumes = os.stat("/volumes") is not None
     except FileNotFoundError:
         logger.warning("Found no volumes to back up")
         has_volumes = False
@@ -219,28 +233,32 @@ def start_backup_process(config, containers):
     # back up volumes
     if has_volumes:
         try:
-            logger.info('Backing up volumes')
-            vol_result = restic.backup_files(config.repository, source='/volumes')
-            logger.debug('Volume backup exit code: %s', vol_result)
+            logger.info("Backing up volumes")
+            vol_result = restic.backup_files(config.repository, source="/volumes")
+            logger.debug("Volume backup exit code: %s", vol_result)
             if vol_result != 0:
-                logger.error('Volume backup exited with non-zero code: %s', vol_result)
+                logger.error("Volume backup exited with non-zero code: %s", vol_result)
                 errors = True
         except Exception as ex:
-            logger.error('Exception raised during volume backup')
+            logger.error("Exception raised during volume backup")
             logger.exception(ex)
             errors = True
 
     # back up databases
-    logger.info('Backing up databases')
+    logger.info("Backing up databases")
     for container in containers.containers_for_backup():
         if container.database_backup_enabled:
             try:
                 instance = container.instance
-                logger.info('Backing up %s in service %s', instance.container_type, instance.service_name)
+                logger.info(
+                    "Backing up %s in service %s",
+                    instance.container_type,
+                    instance.service_name,
+                )
                 result = instance.backup()
-                logger.debug('Exit code: %s', result)
+                logger.debug("Exit code: %s", result)
                 if result != 0:
-                    logger.error('Backup command exited with non-zero code: %s', result)
+                    logger.error("Backup command exited with non-zero code: %s", result)
                     errors = True
             except Exception as ex:
                 logger.exception(ex)
@@ -251,35 +269,35 @@ def start_backup_process(config, containers):
         utils.start_containers(containers.stop_during_backup_containers)
 
     if errors:
-        logger.error('Exit code: %s', errors)
+        logger.error("Exit code: %s", errors)
         exit(1)
 
     # Only run maintenance tasks if maintenance is not scheduled
     if not config.maintenance_schedule:
         maintenance(config, containers)
 
-    logger.info('Backup completed')
-    
+    logger.info("Backup completed")
+
 
 def maintenance(config, containers):
     """Run maintenance tasks"""
-    logger.info('Running maintenance tasks')
+    logger.info("Running maintenance tasks")
     result = cleanup(config, containers)
     if result != 0:
-        logger.error('Cleanup exit code: %s', result)
+        logger.error("Cleanup exit code: %s", result)
         exit(1)
 
     logger.info("Checking the repository for errors")
     check_with_cache = utils.is_true(config.check_with_cache)
     result = restic.check(config.repository, with_cache=check_with_cache)
     if result != 0:
-        logger.error('Check exit code: %s', result)
+        logger.error("Check exit code: %s", result)
         exit(1)
 
 
 def cleanup(config, containers):
     """Run forget / prune to minimize storage space"""
-    logger.info('Forget outdated snapshots')
+    logger.info("Forget outdated snapshots")
     forget_result = restic.forget(
         config.repository,
         config.keep_daily,
@@ -287,7 +305,7 @@ def cleanup(config, containers):
         config.keep_monthly,
         config.keep_yearly,
     )
-    logger.info('Prune stale data freeing storage space')
+    logger.info("Prune stale data freeing storage space")
     prune_result = restic.prune(config.repository)
     return forget_result and prune_result
 
@@ -295,7 +313,7 @@ def cleanup(config, containers):
 def snapshots(config, containers):
     """Display restic snapshots"""
     stdout, stderr = restic.snapshots(config.repository, last=True)
-    for line in stdout.decode().split('\n'):
+    for line in stdout.decode().split("\n"):
         print(line)
 
 
@@ -321,31 +339,31 @@ def dump_env():
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(prog='restic_compose_backup')
+    parser = argparse.ArgumentParser(prog="restic_compose_backup")
     parser.add_argument(
-        'action',
+        "action",
         choices=[
-            'status',
-            'snapshots',
-            'backup',
-            'start-backup-process',
-            'maintenance',
-            'alert',
-            'cleanup',
-            'version',
-            'crontab',
-            'dump-env',
-            'test',
+            "status",
+            "snapshots",
+            "backup",
+            "start-backup-process",
+            "maintenance",
+            "alert",
+            "cleanup",
+            "version",
+            "crontab",
+            "dump-env",
+            "test",
         ],
     )
     parser.add_argument(
-        '--log-level',
+        "--log-level",
         default=None,
         choices=list(log.LOG_LEVELS.keys()),
-        help="Log level"
+        help="Log level",
     )
     return parser.parse_args()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/restic_compose_backup/commands.py
+++ b/src/restic_compose_backup/commands.py
@@ -6,59 +6,68 @@ logger = logging.getLogger(__name__)
 
 
 def test():
-    return run(['ls', '/volumes'])
+    return run(["ls", "/volumes"])
 
 
 def ping_mysql(host, port, username) -> int:
     """Check if the mysql is up and can be reached"""
-    return run([
-        'mysqladmin',
-        'ping',
-        '--host',
-        host,
-        '--port',
-        port,
-        '--user',
-        username,
-    ])
+    return run(
+        [
+            "mysqladmin",
+            "ping",
+            "--host",
+            host,
+            "--port",
+            port,
+            "--user",
+            username,
+        ]
+    )
 
 
 def ping_mariadb(host, port, username) -> int:
     """Check if the mariadb is up and can be reached"""
-    return run([
-        'mysqladmin',
-        'ping',
-        '--host',
-        host,
-        '--port',
-        port,
-        '--user',
-        username,
-    ])
+    return run(
+        [
+            "mysqladmin",
+            "ping",
+            "--host",
+            host,
+            "--port",
+            port,
+            "--user",
+            username,
+        ]
+    )
 
 
 def ping_postgres(host, port, username, password) -> int:
     """Check if postgres can be reached"""
-    return run([
-        "pg_isready",
-        f"--host={host}",
-        f"--port={port}",
-        f"--username={username}",
-    ])
+    return run(
+        [
+            "pg_isready",
+            f"--host={host}",
+            f"--port={port}",
+            f"--username={username}",
+        ]
+    )
 
 
 def run(cmd: List[str]) -> int:
     """Run a command with parameters"""
-    logger.debug('cmd: %s', ' '.join(cmd))
+    logger.debug("cmd: %s", " ".join(cmd))
     child = Popen(cmd, stdout=PIPE, stderr=PIPE)
     stdoutdata, stderrdata = child.communicate()
 
     if stdoutdata.strip():
-        log_std('stdout', stdoutdata.decode(),
-                logging.DEBUG if child.returncode == 0 else logging.ERROR)
+        log_std(
+            "stdout",
+            stdoutdata.decode(),
+            logging.DEBUG if child.returncode == 0 else logging.ERROR,
+        )
 
     if stderrdata.strip():
-        log_std('stderr', stderrdata.decode(), logging.ERROR)
+        log_std("stderr", stderrdata.decode(), logging.ERROR)
 
     logger.debug("returncode %s", child.returncode)
     return child.returncode
@@ -66,7 +75,7 @@ def run(cmd: List[str]) -> int:
 
 def run_capture_std(cmd: List[str]) -> Tuple[str, str]:
     """Run a command with parameters and return stdout, stderr"""
-    logger.debug('cmd: %s', ' '.join(cmd))
+    logger.debug("cmd: %s", " ".join(cmd))
     child = Popen(cmd, stdout=PIPE, stderr=PIPE)
     return child.communicate()
 
@@ -79,13 +88,13 @@ def log_std(source: str, data: str, level: int):
         return
 
     log_func = logger.debug if level == logging.DEBUG else logger.error
-    log_func('%s %s %s', '-' * 10, source, '-' * 10)
+    log_func("%s %s %s", "-" * 10, source, "-" * 10)
 
-    lines = data.split('\n')
-    if lines[-1] == '':
+    lines = data.split("\n")
+    if lines[-1] == "":
         lines.pop()
 
     for line in lines:
         log_func(line)
 
-    log_func('-' * 28)
+    log_func("-" * 28)

--- a/src/restic_compose_backup/config.py
+++ b/src/restic_compose_backup/config.py
@@ -3,37 +3,59 @@ import os
 
 logger = logging.getLogger(__name__)
 
+
 class Config:
     default_backup_command = "source /.env && rcb backup > /proc/1/fd/1"
     default_crontab_schedule = "0 2 * * *"
     default_maintenance_command = "source /.env && rcb maintenance > /proc/1/fd/1"
 
     """Bag for config values"""
+
     def __init__(self, check=True):
         # Mandatory values
-        self.repository = os.environ.get('RESTIC_REPOSITORY')
-        self.password = os.environ.get('RESTIC_REPOSITORY')
-        self.check_with_cache = os.environ.get('CHECK_WITH_CACHE') or False
-        self.cron_schedule = os.environ.get('CRON_SCHEDULE') or self.default_crontab_schedule
-        self.cron_command = os.environ.get('CRON_COMMAND') or self.default_backup_command
-        self.maintenance_schedule = os.environ.get('MAINTENANCE_SCHEDULE') or ""
-        self.maintenance_command = os.environ.get('MAINTENANCE_COMMAND') or self.default_maintenance_command
-        self.swarm_mode = os.environ.get('SWARM_MODE') or False
-        self.include_project_name = os.environ.get('INCLUDE_PROJECT_NAME') or False
-        self.exclude_bind_mounts = os.environ.get('EXCLUDE_BIND_MOUNTS') or False
-        self.include_all_volumes = os.environ.get('INCLUDE_ALL_VOLUMES') or False
+        self.repository = os.environ.get("RESTIC_REPOSITORY")
+        self.password = os.environ.get("RESTIC_REPOSITORY")
+        self.check_with_cache = os.environ.get("CHECK_WITH_CACHE") or False
+        self.cron_schedule = (
+            os.environ.get("CRON_SCHEDULE") or self.default_crontab_schedule
+        )
+        self.cron_command = (
+            os.environ.get("CRON_COMMAND") or self.default_backup_command
+        )
+        self.maintenance_schedule = os.environ.get("MAINTENANCE_SCHEDULE") or ""
+        self.maintenance_command = (
+            os.environ.get("MAINTENANCE_COMMAND") or self.default_maintenance_command
+        )
+        self.swarm_mode = os.environ.get("SWARM_MODE") or False
+        self.include_project_name = os.environ.get("INCLUDE_PROJECT_NAME") or False
+        self.exclude_bind_mounts = os.environ.get("EXCLUDE_BIND_MOUNTS") or False
+        self.include_all_volumes = os.environ.get("INCLUDE_ALL_VOLUMES") or False
         if self.include_all_volumes:
-            logger.warning("INCLUDE_ALL_VOLUMES will be deprecated in the future in favor of AUTO_BACKUP_ALL. Please update your environment variables.")
-        self.auto_backup_all = os.environ.get('AUTO_BACKUP_ALL') or self.include_all_volumes
+            logger.warning(
+                "INCLUDE_ALL_VOLUMES will be deprecated in the future in favor of AUTO_BACKUP_ALL. Please update your environment variables."
+            )
+        self.auto_backup_all = (
+            os.environ.get("AUTO_BACKUP_ALL") or self.include_all_volumes
+        )
 
         # Log
-        self.log_level = os.environ.get('LOG_LEVEL')
+        self.log_level = os.environ.get("LOG_LEVEL")
 
         # forget / keep
-        self.keep_daily = os.environ.get('RESTIC_KEEP_DAILY') or os.environ.get("KEEP_DAILY") or "7"
-        self.keep_weekly = os.environ.get('RESTIC_KEEP_WEEKLY') or os.environ.get("KEEP_WEEKLY") or "4"
-        self.keep_monthly = os.environ.get('RESTIC_KEEP_MONTHLY') or os.environ.get("KEEP_MONTHLY") or "12"
-        self.keep_yearly = os.environ.get('RESTIC_KEEP_YEARLY') or os.environ.get("KEEP_YEARLY") or "3"
+        self.keep_daily = (
+            os.environ.get("RESTIC_KEEP_DAILY") or os.environ.get("KEEP_DAILY") or "7"
+        )
+        self.keep_weekly = (
+            os.environ.get("RESTIC_KEEP_WEEKLY") or os.environ.get("KEEP_WEEKLY") or "4"
+        )
+        self.keep_monthly = (
+            os.environ.get("RESTIC_KEEP_MONTHLY")
+            or os.environ.get("KEEP_MONTHLY")
+            or "12"
+        )
+        self.keep_yearly = (
+            os.environ.get("RESTIC_KEEP_YEARLY") or os.environ.get("KEEP_YEARLY") or "3"
+        )
 
         if check:
             self.check()

--- a/src/restic_compose_backup/containers.py
+++ b/src/restic_compose_backup/containers.py
@@ -396,7 +396,6 @@ class Mount:
 
 
 class RunningContainers:
-
     def __init__(self):
         all_containers = utils.list_containers()
         self.containers = []

--- a/src/restic_compose_backup/containers_db.py
+++ b/src/restic_compose_backup/containers_db.py
@@ -10,32 +10,32 @@ from restic_compose_backup import utils
 
 
 class MariadbContainer(Container):
-    container_type = 'mariadb'
+    container_type = "mariadb"
 
     def get_credentials(self) -> dict:
         """dict: get credentials for the service"""
-        password = self.get_config_env('MARIADB_ROOT_PASSWORD')
+        password = self.get_config_env("MARIADB_ROOT_PASSWORD")
         if password is not None:
             username = "root"
         else:
-            username = self.get_config_env('MARIADB_USER')
-            password = self.get_config_env('MARIADB_PASSWORD')
+            username = self.get_config_env("MARIADB_USER")
+            password = self.get_config_env("MARIADB_PASSWORD")
         return {
-            'host': self.hostname,
-            'username': username,
-            'password': password,
-            'port': "3306",
+            "host": self.hostname,
+            "username": username,
+            "password": password,
+            "port": "3306",
         }
 
     def ping(self) -> bool:
         """Check the availability of the service"""
         creds = self.get_credentials()
 
-        with utils.environment('MYSQL_PWD', creds['password']):
+        with utils.environment("MYSQL_PWD", creds["password"]):
             return commands.ping_mariadb(
-                creds['host'],
-                creds['port'],
-                creds['username'],
+                creds["host"],
+                creds["port"],
+                creds["username"],
             )
 
     def dump_command(self) -> list:
@@ -51,14 +51,14 @@ class MariadbContainer(Container):
             "--single-transaction",
             "--order-by-primary",
             "--compact",
-            "--force"
+            "--force",
         ]
 
     def backup(self):
         config = Config()
         creds = self.get_credentials()
 
-        with utils.environment('MYSQL_PWD', creds['password']):
+        with utils.environment("MYSQL_PWD", creds["password"]):
             return restic.backup_from_stdin(
                 config.repository,
                 self.backup_destination_path(),
@@ -80,32 +80,32 @@ class MariadbContainer(Container):
 
 
 class MysqlContainer(Container):
-    container_type = 'mysql'
+    container_type = "mysql"
 
     def get_credentials(self) -> dict:
         """dict: get credentials for the service"""
-        password = self.get_config_env('MYSQL_ROOT_PASSWORD')
+        password = self.get_config_env("MYSQL_ROOT_PASSWORD")
         if password is not None:
             username = "root"
         else:
-            username = self.get_config_env('MYSQL_USER')
-            password = self.get_config_env('MYSQL_PASSWORD')
+            username = self.get_config_env("MYSQL_USER")
+            password = self.get_config_env("MYSQL_PASSWORD")
         return {
-            'host': self.hostname,
-            'username': username,
-            'password': password,
-            'port': "3306",
+            "host": self.hostname,
+            "username": username,
+            "password": password,
+            "port": "3306",
         }
 
     def ping(self) -> bool:
         """Check the availability of the service"""
         creds = self.get_credentials()
 
-        with utils.environment('MYSQL_PWD', creds['password']):
+        with utils.environment("MYSQL_PWD", creds["password"]):
             return commands.ping_mysql(
-                creds['host'],
-                creds['port'],
-                creds['username'],
+                creds["host"],
+                creds["port"],
+                creds["username"],
             )
 
     def dump_command(self) -> list:
@@ -121,14 +121,14 @@ class MysqlContainer(Container):
             "--single-transaction",
             "--order-by-primary",
             "--compact",
-            "--force"
+            "--force",
         ]
 
     def backup(self):
         config = Config()
         creds = self.get_credentials()
 
-        with utils.environment('MYSQL_PWD', creds['password']):
+        with utils.environment("MYSQL_PWD", creds["password"]):
             return restic.backup_from_stdin(
                 config.repository,
                 self.backup_destination_path(),
@@ -150,26 +150,26 @@ class MysqlContainer(Container):
 
 
 class PostgresContainer(Container):
-    container_type = 'postgres'
+    container_type = "postgres"
 
     def get_credentials(self) -> dict:
         """dict: get credentials for the service"""
         return {
-            'host': self.hostname,
-            'username': self.get_config_env('POSTGRES_USER'),
-            'password': self.get_config_env('POSTGRES_PASSWORD'),
-            'port': "5432",
-            'database': self.get_config_env('POSTGRES_DB'),
+            "host": self.hostname,
+            "username": self.get_config_env("POSTGRES_USER"),
+            "password": self.get_config_env("POSTGRES_PASSWORD"),
+            "port": "5432",
+            "database": self.get_config_env("POSTGRES_DB"),
         }
 
     def ping(self) -> bool:
         """Check the availability of the service"""
         creds = self.get_credentials()
         return commands.ping_postgres(
-            creds['host'],
-            creds['port'],
-            creds['username'],
-            creds['password'],
+            creds["host"],
+            creds["port"],
+            creds["username"],
+            creds["password"],
         )
 
     def dump_command(self) -> list:
@@ -181,14 +181,14 @@ class PostgresContainer(Container):
             f"--host={creds['host']}",
             f"--port={creds['port']}",
             f"--username={creds['username']}",
-            creds['database'],
+            creds["database"],
         ]
 
     def backup(self):
         config = Config()
         creds = self.get_credentials()
 
-        with utils.environment('PGPASSWORD', creds['password']):
+        with utils.environment("PGPASSWORD", creds["password"]):
             return restic.backup_from_stdin(
                 config.repository,
                 self.backup_destination_path(),

--- a/src/restic_compose_backup/cron.py
+++ b/src/restic_compose_backup/cron.py
@@ -9,6 +9,7 @@
 # │ │ │ │ │
 # * * * * * command to execute
 """
+
 QUOTE_CHARS = ['"', "'"]
 
 
@@ -25,16 +26,16 @@ def generate_crontab(config):
     else:
         backup_schedule = config.default_crontab_schedule
 
-    crontab = f'{backup_schedule} {backup_command}\n'
-    
+    crontab = f"{backup_schedule} {backup_command}\n"
+
     maintenance_command = config.maintenance_command.strip()
     maintenance_schedule = config.maintenance_schedule
-    
+
     if maintenance_schedule:
         maintenance_schedule = maintenance_schedule.strip()
         maintenance_schedule = strip_quotes(maintenance_schedule)
         if validate_schedule(maintenance_schedule):
-            crontab += f'{maintenance_schedule} {maintenance_command}\n'
+            crontab += f"{maintenance_schedule} {maintenance_command}\n"
 
     return crontab
 
@@ -46,7 +47,7 @@ def validate_schedule(schedule: str):
         return False
 
     for p in parts:
-        if p != '*' and not p.isdigit():
+        if p != "*" and not p.isdigit():
             return False
 
     minute, hour, day, month, weekday = parts
@@ -63,7 +64,7 @@ def validate_schedule(schedule: str):
 
 
 def validate_field(value, min, max):
-    if value == '*':
+    if value == "*":
         return
 
     i = int(value)

--- a/src/restic_compose_backup/enums.py
+++ b/src/restic_compose_backup/enums.py
@@ -1,12 +1,11 @@
-
 # Labels
-LABEL_VOLUMES_ENABLED = 'stack-back.volumes'
-LABEL_VOLUMES_INCLUDE = 'stack-back.volumes.include'
-LABEL_VOLUMES_EXCLUDE = 'stack-back.volumes.exclude'
-LABEL_STOP_DURING_BACKUP = 'stack-back.volumes.stop-during-backup'
+LABEL_VOLUMES_ENABLED = "stack-back.volumes"
+LABEL_VOLUMES_INCLUDE = "stack-back.volumes.include"
+LABEL_VOLUMES_EXCLUDE = "stack-back.volumes.exclude"
+LABEL_STOP_DURING_BACKUP = "stack-back.volumes.stop-during-backup"
 
-LABEL_MYSQL_ENABLED = 'stack-back.mysql'
-LABEL_POSTGRES_ENABLED = 'stack-back.postgres'
-LABEL_MARIADB_ENABLED = 'stack-back.mariadb'
+LABEL_MYSQL_ENABLED = "stack-back.mysql"
+LABEL_POSTGRES_ENABLED = "stack-back.postgres"
+LABEL_MARIADB_ENABLED = "stack-back.mariadb"
 
-LABEL_BACKUP_PROCESS = 'stack-back.process'
+LABEL_BACKUP_PROCESS = "stack-back.process"

--- a/src/restic_compose_backup/log.py
+++ b/src/restic_compose_backup/log.py
@@ -2,19 +2,19 @@ import logging
 import os
 import sys
 
-logger = logging.getLogger('restic_compose_backup')
-HOSTNAME = os.environ['HOSTNAME']
+logger = logging.getLogger("restic_compose_backup")
+HOSTNAME = os.environ["HOSTNAME"]
 
 DEFAULT_LOG_LEVEL = logging.INFO
 LOG_LEVELS = {
-    'debug': logging.DEBUG,
-    'info': logging.INFO,
-    'warning': logging.WARNING,
-    'error': logging.ERROR,
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
 }
 
 
-def setup(level: str = 'warning'):
+def setup(level: str = "warning"):
     """Set up logging"""
     level = level or ""
     level = LOG_LEVELS.get(level.lower(), DEFAULT_LOG_LEVEL)
@@ -24,5 +24,5 @@ def setup(level: str = 'warning'):
     ch.setLevel(level)
     # ch.setFormatter(logging.Formatter('%(asctime)s - {HOSTNAME} - %(name)s - %(levelname)s - %(message)s'))
     # ch.setFormatter(logging.Formatter('%(asctime)s - {HOSTNAME} - %(levelname)s - %(message)s'))
-    ch.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s: %(message)s'))
+    ch.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s: %(message)s"))
     logger.addHandler(ch)

--- a/src/restic_compose_backup/restic.py
+++ b/src/restic_compose_backup/restic.py
@@ -1,6 +1,7 @@
 """
 Restic commands
 """
+
 import logging
 from typing import List, Tuple
 from subprocess import Popen, PIPE
@@ -14,17 +15,27 @@ def init_repo(repository: str):
     Attempt to initialize the repository.
     Doing this after the repository is initialized
     """
-    return commands.run(restic(repository, [
-        "init",
-    ]))
+    return commands.run(
+        restic(
+            repository,
+            [
+                "init",
+            ],
+        )
+    )
 
 
-def backup_files(repository: str, source='/volumes'):
-    return commands.run(restic(repository, [
-        "--verbose",
-        "backup",
-        source,
-    ]))
+def backup_files(repository: str, source="/volumes"):
+    return commands.run(
+        restic(
+            repository,
+            [
+                "--verbose",
+                "backup",
+                source,
+            ],
+        )
+    )
 
 
 def backup_from_stdin(repository: str, filename: str, source_command: List[str]):
@@ -32,16 +43,25 @@ def backup_from_stdin(repository: str, filename: str, source_command: List[str])
     Backs up from stdin running the source_command passed in.
     It will appear in restic with the filename (including path) passed in.
     """
-    dest_command = restic(repository, [
-        'backup',
-        '--stdin',
-        '--stdin-filename',
-        filename,
-    ])
+    dest_command = restic(
+        repository,
+        [
+            "backup",
+            "--stdin",
+            "--stdin-filename",
+            filename,
+        ],
+    )
 
     # pipe source command into dest command
     source_process = Popen(source_command, stdout=PIPE, bufsize=65536)
-    dest_process = Popen(dest_command, stdin=source_process.stdout, stdout=PIPE, stderr=PIPE, bufsize=65536)
+    dest_process = Popen(
+        dest_command,
+        stdin=source_process.stdout,
+        stdout=PIPE,
+        stderr=PIPE,
+        bufsize=65536,
+    )
     stdout, stderr = dest_process.communicate()
 
     # Ensure both processes exited with code 0
@@ -49,10 +69,12 @@ def backup_from_stdin(repository: str, filename: str, source_command: List[str])
     exit_code = 0 if (source_exit == 0 and dest_exit == 0) else 1
 
     if stdout:
-        commands.log_std('stdout', stdout, logging.DEBUG if exit_code == 0 else logging.ERROR)
+        commands.log_std(
+            "stdout", stdout, logging.DEBUG if exit_code == 0 else logging.ERROR
+        )
 
     if stderr:
-        commands.log_std('stderr', stderr, logging.ERROR)
+        commands.log_std("stderr", stderr, logging.ERROR)
 
     return exit_code
 
@@ -82,25 +104,35 @@ def is_initialized(repository: str) -> bool:
 
 
 def forget(repository: str, daily: str, weekly: str, monthly: str, yearly: str):
-    return commands.run(restic(repository, [
-        'forget',
-        '--group-by',
-        'paths',
-        '--keep-daily',
-        daily,
-        '--keep-weekly',
-        weekly,
-        '--keep-monthly',
-        monthly,
-        '--keep-yearly',
-        yearly,
-    ]))
+    return commands.run(
+        restic(
+            repository,
+            [
+                "forget",
+                "--group-by",
+                "paths",
+                "--keep-daily",
+                daily,
+                "--keep-weekly",
+                weekly,
+                "--keep-monthly",
+                monthly,
+                "--keep-yearly",
+                yearly,
+            ],
+        )
+    )
 
 
 def prune(repository: str):
-    return commands.run(restic(repository, [
-        'prune',
-    ]))
+    return commands.run(
+        restic(
+            repository,
+            [
+                "prune",
+            ],
+        )
+    )
 
 
 def check(repository: str, with_cache: bool = False):

--- a/src/restic_compose_backup/utils.py
+++ b/src/restic_compose_backup/utils.py
@@ -9,8 +9,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-TRUE_VALUES = ['1', 'true', 'True', 'TRUE', True, 1]
-FALSE_VALUES = ['0', 'false', 'False', 'FALSE', False, 0]
+TRUE_VALUES = ["1", "true", "True", "TRUE", True, 1]
+FALSE_VALUES = ["0", "false", "False", "FALSE", False, 0]
 
 
 def docker_client():
@@ -22,8 +22,8 @@ def docker_client():
         DOCKER_CERT_PATH=''
     """
     # NOTE: Remove this fallback in 1.0
-    if not os.environ.get('DOCKER_HOST'):
-        os.environ['DOCKER_HOST'] = 'unix://tmp/docker.sock'
+    if not os.environ.get("DOCKER_HOST"):
+        os.environ["DOCKER_HOST"] = "unix://tmp/docker.sock"
 
     return docker.from_env()
 
@@ -53,33 +53,35 @@ def get_swarm_nodes():
         return []
 
 
-def remove_containers(containers: List['Container']):
+def remove_containers(containers: List["Container"]):
     client = docker_client()
-    logger.info('Attempting to delete stale backup process containers')
+    logger.info("Attempting to delete stale backup process containers")
     for container in containers:
-        logger.info(' -> deleting %s', container.name)
+        logger.info(" -> deleting %s", container.name)
         try:
             c = client.containers.get(container.name)
             c.remove()
         except Exception as ex:
             logger.exception(ex)
-            
-def stop_containers(containers: List['Container']):
+
+
+def stop_containers(containers: List["Container"]):
     client = docker_client()
-    logger.info('Attempting to stop containers labeled to stop during backup')
+    logger.info("Attempting to stop containers labeled to stop during backup")
     for container in containers:
-        logger.info(' -> stopping %s', container.name)
+        logger.info(" -> stopping %s", container.name)
         try:
             c = client.containers.get(container.name)
             c.stop()
         except Exception as ex:
             logger.exception(ex)
-            
-def start_containers(containers: List['Container']):
+
+
+def start_containers(containers: List["Container"]):
     client = docker_client()
-    logger.info('Attempting to restart containers that were stopped during backup')
+    logger.info("Attempting to restart containers that were stopped during backup")
     for container in containers:
-        logger.info(' -> starting %s', container.name)
+        logger.info(" -> starting %s", container.name)
         try:
             c = client.containers.get(container.name)
             c.start()
@@ -107,7 +109,7 @@ def strip_root(path):
     Example: /srv/data becomes srv/data
     """
     path = path.strip()
-    if path.startswith('/'):
+    if path.startswith("/"):
         return path[1:]
 
     return path

--- a/src/tests/fixtures.py
+++ b/src/tests/fixtures.py
@@ -1,4 +1,5 @@
 """Generate test fixtures"""
+
 from datetime import datetime
 import hashlib
 import string
@@ -30,26 +31,30 @@ def containers(project="default", containers=[]):
                 ]
             }
     """
+
     def wrapper(*args, **kwargs):
         return [
-        {
-            'Id': container.get('id', generate_sha256()),
-            'Name': container.get('service') + '_' + ''.join(random.choice(string.ascii_lowercase) for i in range(16)),
-            'Config': {
-                'Image': container.get('image', 'image:latest'),
-                'Labels': {
-                    'com.docker.compose.oneoff': 'False',
-                    'com.docker.compose.project': project,
-                    'com.docker.compose.service': container['service'],
-                    **container.get('labels', {}),
+            {
+                "Id": container.get("id", generate_sha256()),
+                "Name": container.get("service")
+                + "_"
+                + "".join(random.choice(string.ascii_lowercase) for i in range(16)),
+                "Config": {
+                    "Image": container.get("image", "image:latest"),
+                    "Labels": {
+                        "com.docker.compose.oneoff": "False",
+                        "com.docker.compose.project": project,
+                        "com.docker.compose.service": container["service"],
+                        **container.get("labels", {}),
+                    },
                 },
-            },
-            'Mounts': container.get('mounts', []),
-            'State': {
-                "Status": "running",
-                "Running": True,
+                "Mounts": container.get("mounts", []),
+                "State": {
+                    "Status": "running",
+                    "Running": True,
+                },
             }
-        }
-        for container in containers]
+            for container in containers
+        ]
 
     return wrapper

--- a/src/tests/tests.py
+++ b/src/tests/tests.py
@@ -3,14 +3,14 @@ import os
 import unittest
 from unittest import mock
 
-os.environ['RESTIC_REPOSITORY'] = "test"
-os.environ['RESTIC_PASSWORD'] = "password"
+os.environ["RESTIC_REPOSITORY"] = "test"
+os.environ["RESTIC_PASSWORD"] = "password"
 
 from restic_compose_backup import utils, config
 from restic_compose_backup.containers import RunningContainers
 import fixtures
 
-list_containers_func = 'restic_compose_backup.utils.list_containers'
+list_containers_func = "restic_compose_backup.utils.list_containers"
 
 
 class BaseTestCase(unittest.TestCase):
@@ -22,67 +22,78 @@ class BaseTestCase(unittest.TestCase):
 
     def createContainers(self):
         backup_hash = fixtures.generate_sha256()
-        os.environ['HOSTNAME'] = backup_hash[:8]
+        os.environ["HOSTNAME"] = backup_hash[:8]
         return [
             {
-                'id': backup_hash,
-                'service': 'backup',
+                "id": backup_hash,
+                "service": "backup",
             }
         ]
+
 
 class ResticBackupTests(BaseTestCase):
     def test_list_containers(self):
         """Test a basic container list"""
         containers = [
             {
-                'service': 'web',
-                'labels': {
-                    'moo': 1,
+                "service": "web",
+                "labels": {
+                    "moo": 1,
                 },
-                'mounts': [{
-                    'Source': 'moo',
-                    'Destination': 'moo',
-                    'Type': 'bind',
-                }]
+                "mounts": [
+                    {
+                        "Source": "moo",
+                        "Destination": "moo",
+                        "Type": "bind",
+                    }
+                ],
             },
             {
-                'service': 'mysql',
+                "service": "mysql",
             },
             {
-                'service': 'postgres',
+                "service": "postgres",
             },
         ]
 
-        with mock.patch(list_containers_func, fixtures.containers(containers=containers)):
+        with mock.patch(
+            list_containers_func, fixtures.containers(containers=containers)
+        ):
             test = utils.list_containers()
 
     def test_running_containers(self):
         containers = self.createContainers()
         containers += [
             {
-                'service': 'web',
-                'labels': {
-                    'stack-back.volumes': True,
-                    'test': 'test',
+                "service": "web",
+                "labels": {
+                    "stack-back.volumes": True,
+                    "test": "test",
                 },
-                'mounts': [{
-                    'Source': 'test',
-                    'Destination': 'test',
-                    'Type': 'bind',
-                }]
+                "mounts": [
+                    {
+                        "Source": "test",
+                        "Destination": "test",
+                        "Type": "bind",
+                    }
+                ],
             },
             {
-                'service': 'mysql',
+                "service": "mysql",
             },
             {
-                'service': 'postgres',
+                "service": "postgres",
             },
         ]
-        with mock.patch(list_containers_func, fixtures.containers(containers=containers)):
+        with mock.patch(
+            list_containers_func, fixtures.containers(containers=containers)
+        ):
             result = RunningContainers()
             self.assertEqual(len(result.containers), 4, msg="Three containers expected")
-            self.assertNotEqual(result.this_container, None, msg="No backup container found")
-            web_service = result.get_service('web')
+            self.assertNotEqual(
+                result.this_container, None, msg="No backup container found"
+            )
+            web_service = result.get_service("web")
             self.assertNotEqual(web_service, None)
             self.assertEqual(len(web_service.filter_mounts()), 1)
 
@@ -90,33 +101,42 @@ class ResticBackupTests(BaseTestCase):
         containers = self.createContainers()
         containers += [
             {
-                'service': 'web',
-                'labels': {
-                    'stack-back.volumes': True,
+                "service": "web",
+                "labels": {
+                    "stack-back.volumes": True,
                 },
-                'mounts': [{
-                    'Source': 'test',
-                    'Destination': 'test',
-                    'Type': 'bind',
-                }]
+                "mounts": [
+                    {
+                        "Source": "test",
+                        "Destination": "test",
+                        "Type": "bind",
+                    }
+                ],
             },
             {
-                'service': 'mysql',
-                'labels': {
-                    'stack-back.mysql': True,
+                "service": "mysql",
+                "labels": {
+                    "stack-back.mysql": True,
                 },
-                'mounts': [{
-                    'Source': 'data',
-                    'Destination': 'data',
-                    'Type': 'bind',
-                }]
+                "mounts": [
+                    {
+                        "Source": "data",
+                        "Destination": "data",
+                        "Type": "bind",
+                    }
+                ],
             },
         ]
-        with mock.patch(list_containers_func, fixtures.containers(containers=containers)):
+        with mock.patch(
+            list_containers_func, fixtures.containers(containers=containers)
+        ):
             cnt = RunningContainers()
             self.assertTrue(len(cnt.containers_for_backup()) == 2)
-            self.assertEqual(cnt.generate_backup_mounts(), {'test': {'bind': '/volumes/web/test', 'mode': 'ro'}})
-        mysql_service = cnt.get_service('mysql')
+            self.assertEqual(
+                cnt.generate_backup_mounts(),
+                {"test": {"bind": "/volumes/web/test", "mode": "ro"}},
+            )
+        mysql_service = cnt.get_service("mysql")
         self.assertNotEqual(mysql_service, None, msg="MySQL service not found")
         mounts = mysql_service.filter_mounts()
         print(mounts)
@@ -127,16 +147,18 @@ class ResticBackupTests(BaseTestCase):
         containers = self.createContainers()
         containers += [
             {
-                'service': 'web',
-                'labels': {
-                    'stack-back.volumes': True,
+                "service": "web",
+                "labels": {
+                    "stack-back.volumes": True,
                 },
             },
         ]
-        with mock.patch(list_containers_func, fixtures.containers(containers=containers)):
+        with mock.patch(
+            list_containers_func, fixtures.containers(containers=containers)
+        ):
             cnt = RunningContainers()
             self.assertTrue(len(cnt.containers_for_backup()) == 1)
-        web_service = cnt.get_service('web')
+        web_service = cnt.get_service("web")
         self.assertNotEqual(web_service, None, msg="Web service not found")
         mounts = web_service.filter_mounts()
         print(mounts)
@@ -146,20 +168,22 @@ class ResticBackupTests(BaseTestCase):
         containers = self.createContainers()
         containers += [
             {
-                'service': 'mysql',
-                'labels': {
-                    'stack-back.mysql': True,
+                "service": "mysql",
+                "labels": {
+                    "stack-back.mysql": True,
                 },
-                'mounts': [{
-                    'Source': '/srv/mysql/data',
-                    'Destination': '/var/lib/mysql',
-                    'Type': 'bind',
-                }]
+                "mounts": [
+                    {
+                        "Source": "/srv/mysql/data",
+                        "Destination": "/var/lib/mysql",
+                        "Type": "bind",
+                    }
+                ],
             },
             {
                 "service": "mariadb",
-                'labels': {
-                    'stack-back.mariadb': True,
+                "labels": {
+                    "stack-back.mariadb": True,
                 },
                 "mounts": [
                     {
@@ -171,8 +195,8 @@ class ResticBackupTests(BaseTestCase):
             },
             {
                 "service": "postgres",
-                'labels': {
-                    'stack-back.postgres': True,
+                "labels": {
+                    "stack-back.postgres": True,
                 },
                 "mounts": [
                     {
@@ -183,15 +207,17 @@ class ResticBackupTests(BaseTestCase):
                 ],
             },
         ]
-        with mock.patch(list_containers_func, fixtures.containers(containers=containers)):
+        with mock.patch(
+            list_containers_func, fixtures.containers(containers=containers)
+        ):
             cnt = RunningContainers()
-        mysql_service = cnt.get_service('mysql')
+        mysql_service = cnt.get_service("mysql")
         self.assertNotEqual(mysql_service, None, msg="MySQL service not found")
         self.assertTrue(mysql_service.mysql_backup_enabled)
-        mariadb_service = cnt.get_service('mariadb')
+        mariadb_service = cnt.get_service("mariadb")
         self.assertNotEqual(mariadb_service, None, msg="MariaDB service not found")
         self.assertTrue(mariadb_service.mariadb_backup_enabled)
-        postgres_service = cnt.get_service('postgres')
+        postgres_service = cnt.get_service("postgres")
         self.assertNotEqual(postgres_service, None, msg="Posgres service not found")
         self.assertTrue(postgres_service.postgresql_backup_enabled)
 
@@ -199,114 +225,124 @@ class ResticBackupTests(BaseTestCase):
         containers = self.createContainers()
         containers += [
             {
-                'service': 'web',
-                'labels': {
-                    'stack-back.volumes': True,
-                    'stack-back.volumes.include': 'media',
+                "service": "web",
+                "labels": {
+                    "stack-back.volumes": True,
+                    "stack-back.volumes.include": "media",
                 },
-                'mounts': [
+                "mounts": [
                     {
-                        'Source': '/srv/files/media',
-                        'Destination': '/srv/media',
-                        'Type': 'bind',
+                        "Source": "/srv/files/media",
+                        "Destination": "/srv/media",
+                        "Type": "bind",
                     },
                     {
-                        'Source': '/srv/files/stuff',
-                        'Destination': '/srv/stuff',
-                        'Type': 'bind',
+                        "Source": "/srv/files/stuff",
+                        "Destination": "/srv/stuff",
+                        "Type": "bind",
                     },
-                ]
+                ],
             },
         ]
-        with mock.patch(list_containers_func, fixtures.containers(containers=containers)):
+        with mock.patch(
+            list_containers_func, fixtures.containers(containers=containers)
+        ):
             cnt = RunningContainers()
 
-        web_service = cnt.get_service('web')
+        web_service = cnt.get_service("web")
         self.assertNotEqual(web_service, None, msg="Web service not found")
 
         mounts = web_service.filter_mounts()
         print(mounts)
         self.assertEqual(len(mounts), 1)
-        self.assertEqual(mounts[0].source, '/srv/files/media')
+        self.assertEqual(mounts[0].source, "/srv/files/media")
 
     def test_exclude(self):
         containers = self.createContainers()
         containers += [
             {
-                'service': 'web',
-                'labels': {
-                    'stack-back.volumes': True,
-                    'stack-back.volumes.exclude': 'stuff',
+                "service": "web",
+                "labels": {
+                    "stack-back.volumes": True,
+                    "stack-back.volumes.exclude": "stuff",
                 },
-                'mounts': [
+                "mounts": [
                     {
-                        'Source': '/srv/files/media',
-                        'Destination': '/srv/media',
-                        'Type': 'bind',
+                        "Source": "/srv/files/media",
+                        "Destination": "/srv/media",
+                        "Type": "bind",
                     },
                     {
-                        'Source': '/srv/files/stuff',
-                        'Destination': '/srv/stuff',
-                        'Type': 'bind',
+                        "Source": "/srv/files/stuff",
+                        "Destination": "/srv/stuff",
+                        "Type": "bind",
                     },
-                ]
+                ],
             },
         ]
-        with mock.patch(list_containers_func, fixtures.containers(containers=containers)):
+        with mock.patch(
+            list_containers_func, fixtures.containers(containers=containers)
+        ):
             cnt = RunningContainers()
 
-        web_service = cnt.get_service('web')
+        web_service = cnt.get_service("web")
         self.assertNotEqual(web_service, None, msg="Web service not found")
 
         mounts = web_service.filter_mounts()
         self.assertEqual(len(mounts), 1)
-        self.assertEqual(mounts[0].source, '/srv/files/media')
+        self.assertEqual(mounts[0].source, "/srv/files/media")
 
     def test_find_running_backup_container(self):
         containers = self.createContainers()
-        with mock.patch(list_containers_func, fixtures.containers(containers=containers)):
+        with mock.patch(
+            list_containers_func, fixtures.containers(containers=containers)
+        ):
             cnt = RunningContainers()
             self.assertFalse(cnt.backup_process_running)
 
         containers += [
             {
-                'service': 'backup_runner',
-                'labels': {
-                    'stack-back.process-default': 'True',
+                "service": "backup_runner",
+                "labels": {
+                    "stack-back.process-default": "True",
                 },
             },
         ]
-        with mock.patch(list_containers_func, fixtures.containers(containers=containers)):
+        with mock.patch(
+            list_containers_func, fixtures.containers(containers=containers)
+        ):
             cnt = RunningContainers()
             self.assertTrue(cnt.backup_process_running)
-            
+
     def test_stop_container_during_backup_volume(self):
         containers = self.createContainers()
         containers += [
             {
-                'service': 'web',
-                'labels': {
-                    'stack-back.volumes': True,
-                    'stack-back.volumes.include': 'sqlite',
-                    'stack-back.volumes.stop-during-backup': True,
+                "service": "web",
+                "labels": {
+                    "stack-back.volumes": True,
+                    "stack-back.volumes.include": "sqlite",
+                    "stack-back.volumes.stop-during-backup": True,
                 },
-                'mounts': [
+                "mounts": [
                     {
-                        'Source': '/srv/files/media',
-                        'Destination': '/srv/media',
-                        'Type': 'bind',
+                        "Source": "/srv/files/media",
+                        "Destination": "/srv/media",
+                        "Type": "bind",
                     },
                     {
-                        'Source': '/srv/files/sqlite',
-                        'Destination': '/srv/sqlite',
-                        'Type': 'bind',
+                        "Source": "/srv/files/sqlite",
+                        "Destination": "/srv/sqlite",
+                        "Type": "bind",
                     },
-                ]
+                ],
             }
         ]
-        with mock.patch(list_containers_func, fixtures.containers(containers=containers)):
+        with mock.patch(
+            list_containers_func, fixtures.containers(containers=containers)
+        ):
             cnt = RunningContainers()
-        web_service = cnt.get_service('web')
+        web_service = cnt.get_service("web")
         self.assertNotEqual(web_service, None, msg="Web service not found")
         self.assertTrue(web_service.stop_during_backup)
 
@@ -314,24 +350,29 @@ class ResticBackupTests(BaseTestCase):
         containers = self.createContainers()
         containers += [
             {
-                'service': 'mysql',
-                'labels': {
-                    'stack-back.mysql': True,
-                    'stack-back.volumes.stop-during-backup': True,
+                "service": "mysql",
+                "labels": {
+                    "stack-back.mysql": True,
+                    "stack-back.volumes.stop-during-backup": True,
                 },
-                'mounts': [{
-                    'Source': '/srv/mysql/data',
-                    'Destination': '/var/lib/mysql',
-                    'Type': 'bind',
-                }]
+                "mounts": [
+                    {
+                        "Source": "/srv/mysql/data",
+                        "Destination": "/var/lib/mysql",
+                        "Type": "bind",
+                    }
+                ],
             },
         ]
-        with mock.patch(list_containers_func, fixtures.containers(containers=containers)):
+        with mock.patch(
+            list_containers_func, fixtures.containers(containers=containers)
+        ):
             cnt = RunningContainers()
-        mysql_service = cnt.get_service('mysql')
+        mysql_service = cnt.get_service("mysql")
         self.assertNotEqual(mysql_service, None, msg="MySQL service not found")
         self.assertTrue(mysql_service.mysql_backup_enabled)
         self.assertFalse(mysql_service.stop_during_backup)
+
 
 class IncludeAllVolumesTests(BaseTestCase):
     @classmethod
@@ -439,7 +480,7 @@ class IncludeAllVolumesTests(BaseTestCase):
         mounts = postgres_service.filter_mounts()
         print(mounts)
         self.assertEqual(len(mounts), 0)
-        
+
     def test_redundant_volume_label(self):
         """Test that a container has a redundant volume label should be backed up"""
 
@@ -588,9 +629,9 @@ class IncludeAllVolumesTests(BaseTestCase):
         containers += [
             {
                 "service": "mysql",
-                'labels': {
-                    'stack-back.mysql': False,
-                    'stack-back.volumes': False,
+                "labels": {
+                    "stack-back.mysql": False,
+                    "stack-back.volumes": False,
                 },
                 "mounts": [
                     {

--- a/src/uv.lock
+++ b/src/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 1
 requires-python = ">=3.12"
 
 [[package]]
@@ -13,70 +13,70 @@ dependencies = [
     { name = "pathspec" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/49/26a7b0f3f35da4b5a65f081943b7bcd22d7002f5f0fb8098ec1ff21cb6ef/black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666", size = 649449, upload_time = "2025-01-29T04:15:40.373Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/49/26a7b0f3f35da4b5a65f081943b7bcd22d7002f5f0fb8098ec1ff21cb6ef/black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666", size = 649449 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/71/3fe4741df7adf015ad8dfa082dd36c94ca86bb21f25608eb247b4afb15b2/black-25.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b", size = 1650988, upload_time = "2025-01-29T05:37:16.707Z" },
-    { url = "https://files.pythonhosted.org/packages/13/f3/89aac8a83d73937ccd39bbe8fc6ac8860c11cfa0af5b1c96d081facac844/black-25.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc", size = 1453985, upload_time = "2025-01-29T05:37:18.273Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/22/b99efca33f1f3a1d2552c714b1e1b5ae92efac6c43e790ad539a163d1754/black-25.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f", size = 1783816, upload_time = "2025-01-29T04:18:33.823Z" },
-    { url = "https://files.pythonhosted.org/packages/18/7e/a27c3ad3822b6f2e0e00d63d58ff6299a99a5b3aee69fa77cd4b0076b261/black-25.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba", size = 1440860, upload_time = "2025-01-29T04:19:12.944Z" },
-    { url = "https://files.pythonhosted.org/packages/98/87/0edf98916640efa5d0696e1abb0a8357b52e69e82322628f25bf14d263d1/black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f", size = 1650673, upload_time = "2025-01-29T05:37:20.574Z" },
-    { url = "https://files.pythonhosted.org/packages/52/e5/f7bf17207cf87fa6e9b676576749c6b6ed0d70f179a3d812c997870291c3/black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3", size = 1453190, upload_time = "2025-01-29T05:37:22.106Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/ee/adda3d46d4a9120772fae6de454c8495603c37c4c3b9c60f25b1ab6401fe/black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171", size = 1782926, upload_time = "2025-01-29T04:18:58.564Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/64/94eb5f45dcb997d2082f097a3944cfc7fe87e071907f677e80788a2d7b7a/black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18", size = 1442613, upload_time = "2025-01-29T04:19:27.63Z" },
-    { url = "https://files.pythonhosted.org/packages/09/71/54e999902aed72baf26bca0d50781b01838251a462612966e9fc4891eadd/black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717", size = 207646, upload_time = "2025-01-29T04:15:38.082Z" },
+    { url = "https://files.pythonhosted.org/packages/83/71/3fe4741df7adf015ad8dfa082dd36c94ca86bb21f25608eb247b4afb15b2/black-25.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b", size = 1650988 },
+    { url = "https://files.pythonhosted.org/packages/13/f3/89aac8a83d73937ccd39bbe8fc6ac8860c11cfa0af5b1c96d081facac844/black-25.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc", size = 1453985 },
+    { url = "https://files.pythonhosted.org/packages/6f/22/b99efca33f1f3a1d2552c714b1e1b5ae92efac6c43e790ad539a163d1754/black-25.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f", size = 1783816 },
+    { url = "https://files.pythonhosted.org/packages/18/7e/a27c3ad3822b6f2e0e00d63d58ff6299a99a5b3aee69fa77cd4b0076b261/black-25.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba", size = 1440860 },
+    { url = "https://files.pythonhosted.org/packages/98/87/0edf98916640efa5d0696e1abb0a8357b52e69e82322628f25bf14d263d1/black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f", size = 1650673 },
+    { url = "https://files.pythonhosted.org/packages/52/e5/f7bf17207cf87fa6e9b676576749c6b6ed0d70f179a3d812c997870291c3/black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3", size = 1453190 },
+    { url = "https://files.pythonhosted.org/packages/e3/ee/adda3d46d4a9120772fae6de454c8495603c37c4c3b9c60f25b1ab6401fe/black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171", size = 1782926 },
+    { url = "https://files.pythonhosted.org/packages/cc/64/94eb5f45dcb997d2082f097a3944cfc7fe87e071907f677e80788a2d7b7a/black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18", size = 1442613 },
+    { url = "https://files.pythonhosted.org/packages/09/71/54e999902aed72baf26bca0d50781b01838251a462612966e9fc4891eadd/black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717", size = 207646 },
 ]
 
 [[package]]
 name = "certifi"
 version = "2025.4.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6", size = 160705, upload_time = "2025-04-26T02:12:29.51Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6", size = 160705 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3", size = 159618, upload_time = "2025-04-26T02:12:27.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3", size = 159618 },
 ]
 
 [[package]]
 name = "cfgv"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload_time = "2023-08-12T20:38:17.776Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload_time = "2023-08-12T20:38:16.269Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249 },
 ]
 
 [[package]]
 name = "charset-normalizer"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/33/89c2ced2b67d1c2a61c19c6751aa8902d46ce3dacb23600a283619f5a12d/charset_normalizer-3.4.2.tar.gz", hash = "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63", size = 126367, upload_time = "2025-05-02T08:34:42.01Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/33/89c2ced2b67d1c2a61c19c6751aa8902d46ce3dacb23600a283619f5a12d/charset_normalizer-3.4.2.tar.gz", hash = "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63", size = 126367 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/a4/37f4d6035c89cac7930395a35cc0f1b872e652eaafb76a6075943754f095/charset_normalizer-3.4.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0c29de6a1a95f24b9a1aa7aefd27d2487263f00dfd55a77719b530788f75cff7", size = 199936, upload_time = "2025-05-02T08:32:33.712Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/8a/1a5e33b73e0d9287274f899d967907cd0bf9c343e651755d9307e0dbf2b3/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cddf7bd982eaa998934a91f69d182aec997c6c468898efe6679af88283b498d3", size = 143790, upload_time = "2025-05-02T08:32:35.768Z" },
-    { url = "https://files.pythonhosted.org/packages/66/52/59521f1d8e6ab1482164fa21409c5ef44da3e9f653c13ba71becdd98dec3/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a", size = 153924, upload_time = "2025-05-02T08:32:37.284Z" },
-    { url = "https://files.pythonhosted.org/packages/86/2d/fb55fdf41964ec782febbf33cb64be480a6b8f16ded2dbe8db27a405c09f/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d41c4d287cfc69060fa91cae9683eacffad989f1a10811995fa309df656ec214", size = 146626, upload_time = "2025-05-02T08:32:38.803Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/73/6ede2ec59bce19b3edf4209d70004253ec5f4e319f9a2e3f2f15601ed5f7/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e594135de17ab3866138f496755f302b72157d115086d100c3f19370839dd3a", size = 148567, upload_time = "2025-05-02T08:32:40.251Z" },
-    { url = "https://files.pythonhosted.org/packages/09/14/957d03c6dc343c04904530b6bef4e5efae5ec7d7990a7cbb868e4595ee30/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf713fe9a71ef6fd5adf7a79670135081cd4431c2943864757f0fa3a65b1fafd", size = 150957, upload_time = "2025-05-02T08:32:41.705Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/c8/8174d0e5c10ccebdcb1b53cc959591c4c722a3ad92461a273e86b9f5a302/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a370b3e078e418187da8c3674eddb9d983ec09445c99a3a263c2011993522981", size = 145408, upload_time = "2025-05-02T08:32:43.709Z" },
-    { url = "https://files.pythonhosted.org/packages/58/aa/8904b84bc8084ac19dc52feb4f5952c6df03ffb460a887b42615ee1382e8/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a955b438e62efdf7e0b7b52a64dc5c3396e2634baa62471768a64bc2adb73d5c", size = 153399, upload_time = "2025-05-02T08:32:46.197Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/26/89ee1f0e264d201cb65cf054aca6038c03b1a0c6b4ae998070392a3ce605/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7222ffd5e4de8e57e03ce2cef95a4c43c98fcb72ad86909abdfc2c17d227fc1b", size = 156815, upload_time = "2025-05-02T08:32:48.105Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/07/68e95b4b345bad3dbbd3a8681737b4338ff2c9df29856a6d6d23ac4c73cb/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:bee093bf902e1d8fc0ac143c88902c3dfc8941f7ea1d6a8dd2bcb786d33db03d", size = 154537, upload_time = "2025-05-02T08:32:49.719Z" },
-    { url = "https://files.pythonhosted.org/packages/77/1a/5eefc0ce04affb98af07bc05f3bac9094513c0e23b0562d64af46a06aae4/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dedb8adb91d11846ee08bec4c8236c8549ac721c245678282dcb06b221aab59f", size = 149565, upload_time = "2025-05-02T08:32:51.404Z" },
-    { url = "https://files.pythonhosted.org/packages/37/a0/2410e5e6032a174c95e0806b1a6585eb21e12f445ebe239fac441995226a/charset_normalizer-3.4.2-cp312-cp312-win32.whl", hash = "sha256:db4c7bf0e07fc3b7d89ac2a5880a6a8062056801b83ff56d8464b70f65482b6c", size = 98357, upload_time = "2025-05-02T08:32:53.079Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/4f/c02d5c493967af3eda9c771ad4d2bbc8df6f99ddbeb37ceea6e8716a32bc/charset_normalizer-3.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:5a9979887252a82fefd3d3ed2a8e3b937a7a809f65dcb1e068b090e165bbe99e", size = 105776, upload_time = "2025-05-02T08:32:54.573Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/12/a93df3366ed32db1d907d7593a94f1fe6293903e3e92967bebd6950ed12c/charset_normalizer-3.4.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:926ca93accd5d36ccdabd803392ddc3e03e6d4cd1cf17deff3b989ab8e9dbcf0", size = 199622, upload_time = "2025-05-02T08:32:56.363Z" },
-    { url = "https://files.pythonhosted.org/packages/04/93/bf204e6f344c39d9937d3c13c8cd5bbfc266472e51fc8c07cb7f64fcd2de/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eba9904b0f38a143592d9fc0e19e2df0fa2e41c3c3745554761c5f6447eedabf", size = 143435, upload_time = "2025-05-02T08:32:58.551Z" },
-    { url = "https://files.pythonhosted.org/packages/22/2a/ea8a2095b0bafa6c5b5a55ffdc2f924455233ee7b91c69b7edfcc9e02284/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3fddb7e2c84ac87ac3a947cb4e66d143ca5863ef48e4a5ecb83bd48619e4634e", size = 153653, upload_time = "2025-05-02T08:33:00.342Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/57/1b090ff183d13cef485dfbe272e2fe57622a76694061353c59da52c9a659/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98f862da73774290f251b9df8d11161b6cf25b599a66baf087c1ffe340e9bfd1", size = 146231, upload_time = "2025-05-02T08:33:02.081Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/28/ffc026b26f441fc67bd21ab7f03b313ab3fe46714a14b516f931abe1a2d8/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c9379d65defcab82d07b2a9dfbfc2e95bc8fe0ebb1b176a3190230a3ef0e07c", size = 148243, upload_time = "2025-05-02T08:33:04.063Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/0f/9abe9bd191629c33e69e47c6ef45ef99773320e9ad8e9cb08b8ab4a8d4cb/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e635b87f01ebc977342e2697d05b56632f5f879a4f15955dfe8cef2448b51691", size = 150442, upload_time = "2025-05-02T08:33:06.418Z" },
-    { url = "https://files.pythonhosted.org/packages/67/7c/a123bbcedca91d5916c056407f89a7f5e8fdfce12ba825d7d6b9954a1a3c/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c95a1e2902a8b722868587c0e1184ad5c55631de5afc0eb96bc4b0d738092c0", size = 145147, upload_time = "2025-05-02T08:33:08.183Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/fe/1ac556fa4899d967b83e9893788e86b6af4d83e4726511eaaad035e36595/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ef8de666d6179b009dce7bcb2ad4c4a779f113f12caf8dc77f0162c29d20490b", size = 153057, upload_time = "2025-05-02T08:33:09.986Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/ff/acfc0b0a70b19e3e54febdd5301a98b72fa07635e56f24f60502e954c461/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:32fc0341d72e0f73f80acb0a2c94216bd704f4f0bce10aedea38f30502b271ff", size = 156454, upload_time = "2025-05-02T08:33:11.814Z" },
-    { url = "https://files.pythonhosted.org/packages/92/08/95b458ce9c740d0645feb0e96cea1f5ec946ea9c580a94adfe0b617f3573/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:289200a18fa698949d2b39c671c2cc7a24d44096784e76614899a7ccf2574b7b", size = 154174, upload_time = "2025-05-02T08:33:13.707Z" },
-    { url = "https://files.pythonhosted.org/packages/78/be/8392efc43487ac051eee6c36d5fbd63032d78f7728cb37aebcc98191f1ff/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a476b06fbcf359ad25d34a057b7219281286ae2477cc5ff5e3f70a246971148", size = 149166, upload_time = "2025-05-02T08:33:15.458Z" },
-    { url = "https://files.pythonhosted.org/packages/44/96/392abd49b094d30b91d9fbda6a69519e95802250b777841cf3bda8fe136c/charset_normalizer-3.4.2-cp313-cp313-win32.whl", hash = "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7", size = 98064, upload_time = "2025-05-02T08:33:17.06Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/b0/0200da600134e001d91851ddc797809e2fe0ea72de90e09bec5a2fbdaccb/charset_normalizer-3.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980", size = 105641, upload_time = "2025-05-02T08:33:18.753Z" },
-    { url = "https://files.pythonhosted.org/packages/20/94/c5790835a017658cbfabd07f3bfb549140c3ac458cfc196323996b10095a/charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0", size = 52626, upload_time = "2025-05-02T08:34:40.053Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a4/37f4d6035c89cac7930395a35cc0f1b872e652eaafb76a6075943754f095/charset_normalizer-3.4.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0c29de6a1a95f24b9a1aa7aefd27d2487263f00dfd55a77719b530788f75cff7", size = 199936 },
+    { url = "https://files.pythonhosted.org/packages/ee/8a/1a5e33b73e0d9287274f899d967907cd0bf9c343e651755d9307e0dbf2b3/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cddf7bd982eaa998934a91f69d182aec997c6c468898efe6679af88283b498d3", size = 143790 },
+    { url = "https://files.pythonhosted.org/packages/66/52/59521f1d8e6ab1482164fa21409c5ef44da3e9f653c13ba71becdd98dec3/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a", size = 153924 },
+    { url = "https://files.pythonhosted.org/packages/86/2d/fb55fdf41964ec782febbf33cb64be480a6b8f16ded2dbe8db27a405c09f/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d41c4d287cfc69060fa91cae9683eacffad989f1a10811995fa309df656ec214", size = 146626 },
+    { url = "https://files.pythonhosted.org/packages/8c/73/6ede2ec59bce19b3edf4209d70004253ec5f4e319f9a2e3f2f15601ed5f7/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e594135de17ab3866138f496755f302b72157d115086d100c3f19370839dd3a", size = 148567 },
+    { url = "https://files.pythonhosted.org/packages/09/14/957d03c6dc343c04904530b6bef4e5efae5ec7d7990a7cbb868e4595ee30/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf713fe9a71ef6fd5adf7a79670135081cd4431c2943864757f0fa3a65b1fafd", size = 150957 },
+    { url = "https://files.pythonhosted.org/packages/0d/c8/8174d0e5c10ccebdcb1b53cc959591c4c722a3ad92461a273e86b9f5a302/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a370b3e078e418187da8c3674eddb9d983ec09445c99a3a263c2011993522981", size = 145408 },
+    { url = "https://files.pythonhosted.org/packages/58/aa/8904b84bc8084ac19dc52feb4f5952c6df03ffb460a887b42615ee1382e8/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a955b438e62efdf7e0b7b52a64dc5c3396e2634baa62471768a64bc2adb73d5c", size = 153399 },
+    { url = "https://files.pythonhosted.org/packages/c2/26/89ee1f0e264d201cb65cf054aca6038c03b1a0c6b4ae998070392a3ce605/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7222ffd5e4de8e57e03ce2cef95a4c43c98fcb72ad86909abdfc2c17d227fc1b", size = 156815 },
+    { url = "https://files.pythonhosted.org/packages/fd/07/68e95b4b345bad3dbbd3a8681737b4338ff2c9df29856a6d6d23ac4c73cb/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:bee093bf902e1d8fc0ac143c88902c3dfc8941f7ea1d6a8dd2bcb786d33db03d", size = 154537 },
+    { url = "https://files.pythonhosted.org/packages/77/1a/5eefc0ce04affb98af07bc05f3bac9094513c0e23b0562d64af46a06aae4/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dedb8adb91d11846ee08bec4c8236c8549ac721c245678282dcb06b221aab59f", size = 149565 },
+    { url = "https://files.pythonhosted.org/packages/37/a0/2410e5e6032a174c95e0806b1a6585eb21e12f445ebe239fac441995226a/charset_normalizer-3.4.2-cp312-cp312-win32.whl", hash = "sha256:db4c7bf0e07fc3b7d89ac2a5880a6a8062056801b83ff56d8464b70f65482b6c", size = 98357 },
+    { url = "https://files.pythonhosted.org/packages/6c/4f/c02d5c493967af3eda9c771ad4d2bbc8df6f99ddbeb37ceea6e8716a32bc/charset_normalizer-3.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:5a9979887252a82fefd3d3ed2a8e3b937a7a809f65dcb1e068b090e165bbe99e", size = 105776 },
+    { url = "https://files.pythonhosted.org/packages/ea/12/a93df3366ed32db1d907d7593a94f1fe6293903e3e92967bebd6950ed12c/charset_normalizer-3.4.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:926ca93accd5d36ccdabd803392ddc3e03e6d4cd1cf17deff3b989ab8e9dbcf0", size = 199622 },
+    { url = "https://files.pythonhosted.org/packages/04/93/bf204e6f344c39d9937d3c13c8cd5bbfc266472e51fc8c07cb7f64fcd2de/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eba9904b0f38a143592d9fc0e19e2df0fa2e41c3c3745554761c5f6447eedabf", size = 143435 },
+    { url = "https://files.pythonhosted.org/packages/22/2a/ea8a2095b0bafa6c5b5a55ffdc2f924455233ee7b91c69b7edfcc9e02284/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3fddb7e2c84ac87ac3a947cb4e66d143ca5863ef48e4a5ecb83bd48619e4634e", size = 153653 },
+    { url = "https://files.pythonhosted.org/packages/b6/57/1b090ff183d13cef485dfbe272e2fe57622a76694061353c59da52c9a659/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98f862da73774290f251b9df8d11161b6cf25b599a66baf087c1ffe340e9bfd1", size = 146231 },
+    { url = "https://files.pythonhosted.org/packages/e2/28/ffc026b26f441fc67bd21ab7f03b313ab3fe46714a14b516f931abe1a2d8/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c9379d65defcab82d07b2a9dfbfc2e95bc8fe0ebb1b176a3190230a3ef0e07c", size = 148243 },
+    { url = "https://files.pythonhosted.org/packages/c0/0f/9abe9bd191629c33e69e47c6ef45ef99773320e9ad8e9cb08b8ab4a8d4cb/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e635b87f01ebc977342e2697d05b56632f5f879a4f15955dfe8cef2448b51691", size = 150442 },
+    { url = "https://files.pythonhosted.org/packages/67/7c/a123bbcedca91d5916c056407f89a7f5e8fdfce12ba825d7d6b9954a1a3c/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c95a1e2902a8b722868587c0e1184ad5c55631de5afc0eb96bc4b0d738092c0", size = 145147 },
+    { url = "https://files.pythonhosted.org/packages/ec/fe/1ac556fa4899d967b83e9893788e86b6af4d83e4726511eaaad035e36595/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ef8de666d6179b009dce7bcb2ad4c4a779f113f12caf8dc77f0162c29d20490b", size = 153057 },
+    { url = "https://files.pythonhosted.org/packages/2b/ff/acfc0b0a70b19e3e54febdd5301a98b72fa07635e56f24f60502e954c461/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:32fc0341d72e0f73f80acb0a2c94216bd704f4f0bce10aedea38f30502b271ff", size = 156454 },
+    { url = "https://files.pythonhosted.org/packages/92/08/95b458ce9c740d0645feb0e96cea1f5ec946ea9c580a94adfe0b617f3573/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:289200a18fa698949d2b39c671c2cc7a24d44096784e76614899a7ccf2574b7b", size = 154174 },
+    { url = "https://files.pythonhosted.org/packages/78/be/8392efc43487ac051eee6c36d5fbd63032d78f7728cb37aebcc98191f1ff/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a476b06fbcf359ad25d34a057b7219281286ae2477cc5ff5e3f70a246971148", size = 149166 },
+    { url = "https://files.pythonhosted.org/packages/44/96/392abd49b094d30b91d9fbda6a69519e95802250b777841cf3bda8fe136c/charset_normalizer-3.4.2-cp313-cp313-win32.whl", hash = "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7", size = 98064 },
+    { url = "https://files.pythonhosted.org/packages/e9/b0/0200da600134e001d91851ddc797809e2fe0ea72de90e09bec5a2fbdaccb/charset_normalizer-3.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980", size = 105641 },
+    { url = "https://files.pythonhosted.org/packages/20/94/c5790835a017658cbfabd07f3bfb549140c3ac458cfc196323996b10095a/charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0", size = 52626 },
 ]
 
 [[package]]
@@ -86,27 +86,27 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload_time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload_time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload_time = "2022-10-25T02:36:22.414Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload_time = "2022-10-25T02:36:20.889Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
 ]
 
 [[package]]
 name = "distlib"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923, upload_time = "2024-10-09T18:35:47.551Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973, upload_time = "2024-10-09T18:35:44.272Z" },
+    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973 },
 ]
 
 [[package]]
@@ -118,99 +118,99 @@ dependencies = [
     { name = "requests" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload_time = "2024-05-23T11:13:57.216Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload_time = "2024-05-23T11:13:55.01Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774 },
 ]
 
 [[package]]
 name = "filelock"
 version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075, upload_time = "2025-03-14T07:11:40.47Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215, upload_time = "2025-03-14T07:11:39.145Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215 },
 ]
 
 [[package]]
 name = "identify"
 version = "2.6.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/83/b6ea0334e2e7327084a46aaaf71f2146fc061a192d6518c0d020120cd0aa/identify-2.6.10.tar.gz", hash = "sha256:45e92fd704f3da71cc3880036633f48b4b7265fd4de2b57627cb157216eb7eb8", size = 99201, upload_time = "2025-04-19T15:10:38.32Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/83/b6ea0334e2e7327084a46aaaf71f2146fc061a192d6518c0d020120cd0aa/identify-2.6.10.tar.gz", hash = "sha256:45e92fd704f3da71cc3880036633f48b4b7265fd4de2b57627cb157216eb7eb8", size = 99201 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/d3/85feeba1d097b81a44bcffa6a0beab7b4dfffe78e82fc54978d3ac380736/identify-2.6.10-py2.py3-none-any.whl", hash = "sha256:5f34248f54136beed1a7ba6a6b5c4b6cf21ff495aac7c359e1ef831ae3b8ab25", size = 99101, upload_time = "2025-04-19T15:10:36.701Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d3/85feeba1d097b81a44bcffa6a0beab7b4dfffe78e82fc54978d3ac380736/identify-2.6.10-py2.py3-none-any.whl", hash = "sha256:5f34248f54136beed1a7ba6a6b5c4b6cf21ff495aac7c359e1ef831ae3b8ab25", size = 99101 },
 ]
 
 [[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload_time = "2024-09-15T18:07:39.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload_time = "2024-09-15T18:07:37.964Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
 ]
 
 [[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload_time = "2025-03-19T20:09:59.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload_time = "2025-03-19T20:10:01.071Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
 ]
 
 [[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload_time = "2025-04-22T14:54:24.164Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload_time = "2025-04-22T14:54:22.983Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963 },
 ]
 
 [[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload_time = "2024-06-04T18:44:11.171Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload_time = "2024-06-04T18:44:08.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
 ]
 
 [[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload_time = "2025-04-19T11:48:59.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload_time = "2025-04-19T11:48:57.875Z" },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
 ]
 
 [[package]]
 name = "pathspec"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload_time = "2023-12-10T22:30:45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload_time = "2023-12-10T22:30:43.14Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
 ]
 
 [[package]]
 name = "platformdirs"
 version = "4.3.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/2d/7d512a3913d60623e7eb945c6d1b4f0bddf1d0b7ada5225274c87e5b53d1/platformdirs-4.3.7.tar.gz", hash = "sha256:eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351", size = 21291, upload_time = "2025-03-19T20:36:10.989Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/2d/7d512a3913d60623e7eb945c6d1b4f0bddf1d0b7ada5225274c87e5b53d1/platformdirs-4.3.7.tar.gz", hash = "sha256:eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351", size = 21291 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/45/59578566b3275b8fd9157885918fcd0c4d74162928a5310926887b856a51/platformdirs-4.3.7-py3-none-any.whl", hash = "sha256:a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94", size = 18499, upload_time = "2025-03-19T20:36:09.038Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/45/59578566b3275b8fd9157885918fcd0c4d74162928a5310926887b856a51/platformdirs-4.3.7-py3-none-any.whl", hash = "sha256:a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94", size = 18499 },
 ]
 
 [[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload_time = "2024-04-20T21:34:42.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload_time = "2024-04-20T21:34:40.434Z" },
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
 ]
 
 [[package]]
@@ -224,9 +224,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/39/679ca9b26c7bb2999ff122d50faa301e49af82ca9c066ec061cfbc0c6784/pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146", size = 193424, upload_time = "2025-03-18T21:35:20.987Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/39/679ca9b26c7bb2999ff122d50faa301e49af82ca9c066ec061cfbc0c6784/pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146", size = 193424 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/74/a88bf1b1efeae488a0c0b7bdf71429c313722d1fc0f377537fbe554e6180/pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd", size = 220707, upload_time = "2025-03-18T21:35:19.343Z" },
+    { url = "https://files.pythonhosted.org/packages/88/74/a88bf1b1efeae488a0c0b7bdf71429c313722d1fc0f377537fbe554e6180/pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd", size = 220707 },
 ]
 
 [[package]]
@@ -239,9 +239,9 @@ dependencies = [
     { name = "packaging" },
     { name = "pluggy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload_time = "2025-03-02T12:54:54.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload_time = "2025-03-02T12:54:52.069Z" },
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
 ]
 
 [[package]]
@@ -249,38 +249,38 @@ name = "pywin32"
 version = "310"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/ec/4fdbe47932f671d6e348474ea35ed94227fb5df56a7c30cbbb42cd396ed0/pywin32-310-cp312-cp312-win32.whl", hash = "sha256:8a75a5cc3893e83a108c05d82198880704c44bbaee4d06e442e471d3c9ea4f3d", size = 8796239, upload_time = "2025-03-17T00:55:58.807Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/e5/b0627f8bb84e06991bea89ad8153a9e50ace40b2e1195d68e9dff6b03d0f/pywin32-310-cp312-cp312-win_amd64.whl", hash = "sha256:bf5c397c9a9a19a6f62f3fb821fbf36cac08f03770056711f765ec1503972060", size = 9503839, upload_time = "2025-03-17T00:56:00.8Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/32/9ccf53748df72301a89713936645a664ec001abd35ecc8578beda593d37d/pywin32-310-cp312-cp312-win_arm64.whl", hash = "sha256:2349cc906eae872d0663d4d6290d13b90621eaf78964bb1578632ff20e152966", size = 8459470, upload_time = "2025-03-17T00:56:02.601Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/09/9c1b978ffc4ae53999e89c19c77ba882d9fce476729f23ef55211ea1c034/pywin32-310-cp313-cp313-win32.whl", hash = "sha256:5d241a659c496ada3253cd01cfaa779b048e90ce4b2b38cd44168ad555ce74ab", size = 8794384, upload_time = "2025-03-17T00:56:04.383Z" },
-    { url = "https://files.pythonhosted.org/packages/45/3c/b4640f740ffebadd5d34df35fecba0e1cfef8fde9f3e594df91c28ad9b50/pywin32-310-cp313-cp313-win_amd64.whl", hash = "sha256:667827eb3a90208ddbdcc9e860c81bde63a135710e21e4cb3348968e4bd5249e", size = 9503039, upload_time = "2025-03-17T00:56:06.207Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/f4/f785020090fb050e7fb6d34b780f2231f302609dc964672f72bfaeb59a28/pywin32-310-cp313-cp313-win_arm64.whl", hash = "sha256:e308f831de771482b7cf692a1f308f8fca701b2d8f9dde6cc440c7da17e47b33", size = 8458152, upload_time = "2025-03-17T00:56:07.819Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ec/4fdbe47932f671d6e348474ea35ed94227fb5df56a7c30cbbb42cd396ed0/pywin32-310-cp312-cp312-win32.whl", hash = "sha256:8a75a5cc3893e83a108c05d82198880704c44bbaee4d06e442e471d3c9ea4f3d", size = 8796239 },
+    { url = "https://files.pythonhosted.org/packages/e3/e5/b0627f8bb84e06991bea89ad8153a9e50ace40b2e1195d68e9dff6b03d0f/pywin32-310-cp312-cp312-win_amd64.whl", hash = "sha256:bf5c397c9a9a19a6f62f3fb821fbf36cac08f03770056711f765ec1503972060", size = 9503839 },
+    { url = "https://files.pythonhosted.org/packages/1f/32/9ccf53748df72301a89713936645a664ec001abd35ecc8578beda593d37d/pywin32-310-cp312-cp312-win_arm64.whl", hash = "sha256:2349cc906eae872d0663d4d6290d13b90621eaf78964bb1578632ff20e152966", size = 8459470 },
+    { url = "https://files.pythonhosted.org/packages/1c/09/9c1b978ffc4ae53999e89c19c77ba882d9fce476729f23ef55211ea1c034/pywin32-310-cp313-cp313-win32.whl", hash = "sha256:5d241a659c496ada3253cd01cfaa779b048e90ce4b2b38cd44168ad555ce74ab", size = 8794384 },
+    { url = "https://files.pythonhosted.org/packages/45/3c/b4640f740ffebadd5d34df35fecba0e1cfef8fde9f3e594df91c28ad9b50/pywin32-310-cp313-cp313-win_amd64.whl", hash = "sha256:667827eb3a90208ddbdcc9e860c81bde63a135710e21e4cb3348968e4bd5249e", size = 9503039 },
+    { url = "https://files.pythonhosted.org/packages/b4/f4/f785020090fb050e7fb6d34b780f2231f302609dc964672f72bfaeb59a28/pywin32-310-cp313-cp313-win_arm64.whl", hash = "sha256:e308f831de771482b7cf692a1f308f8fca701b2d8f9dde6cc440c7da17e47b33", size = 8458152 },
 ]
 
 [[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload_time = "2024-08-06T20:33:50.674Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873, upload_time = "2024-08-06T20:32:25.131Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302, upload_time = "2024-08-06T20:32:26.511Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154, upload_time = "2024-08-06T20:32:28.363Z" },
-    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223, upload_time = "2024-08-06T20:32:30.058Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542, upload_time = "2024-08-06T20:32:31.881Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164, upload_time = "2024-08-06T20:32:37.083Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload_time = "2024-08-06T20:32:38.898Z" },
-    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload_time = "2024-08-06T20:32:40.241Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload_time = "2024-08-06T20:32:41.93Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload_time = "2024-08-06T20:32:43.4Z" },
-    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload_time = "2024-08-06T20:32:44.801Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload_time = "2024-08-06T20:32:46.432Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload_time = "2024-08-06T20:32:51.188Z" },
-    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload_time = "2024-08-06T20:32:53.019Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload_time = "2024-08-06T20:32:54.708Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload_time = "2024-08-06T20:32:56.985Z" },
-    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload_time = "2024-08-06T20:33:03.001Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload_time = "2024-08-06T20:33:04.33Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873 },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302 },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154 },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223 },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542 },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164 },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611 },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591 },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338 },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309 },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679 },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428 },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361 },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523 },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660 },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
 ]
 
 [[package]]
@@ -293,9 +293,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218, upload_time = "2024-05-29T15:37:49.536Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928, upload_time = "2024-05-29T15:37:47.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928 },
 ]
 
 [[package]]
@@ -311,6 +311,7 @@ dev = [
     { name = "black" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -321,15 +322,41 @@ dev = [
     { name = "black", specifier = ">=25.1.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=7.4.0" },
+    { name = "ruff", specifier = ">=0.12.3" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.12.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/2a/43955b530c49684d3c38fcda18c43caf91e99204c2a065552528e0552d4f/ruff-0.12.3.tar.gz", hash = "sha256:f1b5a4b6668fd7b7ea3697d8d98857390b40c1320a63a178eee6be0899ea2d77", size = 4459341 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/fd/b44c5115539de0d598d75232a1cc7201430b6891808df111b8b0506aae43/ruff-0.12.3-py3-none-linux_armv6l.whl", hash = "sha256:47552138f7206454eaf0c4fe827e546e9ddac62c2a3d2585ca54d29a890137a2", size = 10430499 },
+    { url = "https://files.pythonhosted.org/packages/43/c5/9eba4f337970d7f639a37077be067e4ec80a2ad359e4cc6c5b56805cbc66/ruff-0.12.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0a9153b000c6fe169bb307f5bd1b691221c4286c133407b8827c406a55282041", size = 11213413 },
+    { url = "https://files.pythonhosted.org/packages/e2/2c/fac3016236cf1fe0bdc8e5de4f24c76ce53c6dd9b5f350d902549b7719b2/ruff-0.12.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fa6b24600cf3b750e48ddb6057e901dd5b9aa426e316addb2a1af185a7509882", size = 10586941 },
+    { url = "https://files.pythonhosted.org/packages/c5/0f/41fec224e9dfa49a139f0b402ad6f5d53696ba1800e0f77b279d55210ca9/ruff-0.12.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2506961bf6ead54887ba3562604d69cb430f59b42133d36976421bc8bd45901", size = 10783001 },
+    { url = "https://files.pythonhosted.org/packages/0d/ca/dd64a9ce56d9ed6cad109606ac014860b1c217c883e93bf61536400ba107/ruff-0.12.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c4faaff1f90cea9d3033cbbcdf1acf5d7fb11d8180758feb31337391691f3df0", size = 10269641 },
+    { url = "https://files.pythonhosted.org/packages/63/5c/2be545034c6bd5ce5bb740ced3e7014d7916f4c445974be11d2a406d5088/ruff-0.12.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40dced4a79d7c264389de1c59467d5d5cefd79e7e06d1dfa2c75497b5269a5a6", size = 11875059 },
+    { url = "https://files.pythonhosted.org/packages/8e/d4/a74ef1e801ceb5855e9527dae105eaff136afcb9cc4d2056d44feb0e4792/ruff-0.12.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:0262d50ba2767ed0fe212aa7e62112a1dcbfd46b858c5bf7bbd11f326998bafc", size = 12658890 },
+    { url = "https://files.pythonhosted.org/packages/13/c8/1057916416de02e6d7c9bcd550868a49b72df94e3cca0aeb77457dcd9644/ruff-0.12.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12371aec33e1a3758597c5c631bae9a5286f3c963bdfb4d17acdd2d395406687", size = 12232008 },
+    { url = "https://files.pythonhosted.org/packages/f5/59/4f7c130cc25220392051fadfe15f63ed70001487eca21d1796db46cbcc04/ruff-0.12.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:560f13b6baa49785665276c963edc363f8ad4b4fc910a883e2625bdb14a83a9e", size = 11499096 },
+    { url = "https://files.pythonhosted.org/packages/d4/01/a0ad24a5d2ed6be03a312e30d32d4e3904bfdbc1cdbe63c47be9d0e82c79/ruff-0.12.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:023040a3499f6f974ae9091bcdd0385dd9e9eb4942f231c23c57708147b06311", size = 11688307 },
+    { url = "https://files.pythonhosted.org/packages/93/72/08f9e826085b1f57c9a0226e48acb27643ff19b61516a34c6cab9d6ff3fa/ruff-0.12.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:883d844967bffff5ab28bba1a4d246c1a1b2933f48cb9840f3fdc5111c603b07", size = 10661020 },
+    { url = "https://files.pythonhosted.org/packages/80/a0/68da1250d12893466c78e54b4a0ff381370a33d848804bb51279367fc688/ruff-0.12.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2120d3aa855ff385e0e562fdee14d564c9675edbe41625c87eeab744a7830d12", size = 10246300 },
+    { url = "https://files.pythonhosted.org/packages/6a/22/5f0093d556403e04b6fd0984fc0fb32fbb6f6ce116828fd54306a946f444/ruff-0.12.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6b16647cbb470eaf4750d27dddc6ebf7758b918887b56d39e9c22cce2049082b", size = 11263119 },
+    { url = "https://files.pythonhosted.org/packages/92/c9/f4c0b69bdaffb9968ba40dd5fa7df354ae0c73d01f988601d8fac0c639b1/ruff-0.12.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e1417051edb436230023575b149e8ff843a324557fe0a265863b7602df86722f", size = 11746990 },
+    { url = "https://files.pythonhosted.org/packages/fe/84/7cc7bd73924ee6be4724be0db5414a4a2ed82d06b30827342315a1be9e9c/ruff-0.12.3-py3-none-win32.whl", hash = "sha256:dfd45e6e926deb6409d0616078a666ebce93e55e07f0fb0228d4b2608b2c248d", size = 10589263 },
+    { url = "https://files.pythonhosted.org/packages/07/87/c070f5f027bd81f3efee7d14cb4d84067ecf67a3a8efb43aadfc72aa79a6/ruff-0.12.3-py3-none-win_amd64.whl", hash = "sha256:a946cf1e7ba3209bdef039eb97647f1c77f6f540e5845ec9c114d3af8df873e7", size = 11695072 },
+    { url = "https://files.pythonhosted.org/packages/e0/30/f3eaf6563c637b6e66238ed6535f6775480db973c836336e4122161986fc/ruff-0.12.3-py3-none-win_arm64.whl", hash = "sha256:5f9c7c9c8f84c2d7f27e93674d27136fbf489720251544c4da7fb3d742e011b1", size = 10805855 },
 ]
 
 [[package]]
 name = "urllib3"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672, upload_time = "2025-04-10T15:23:39.232Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680, upload_time = "2025-04-10T15:23:37.377Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680 },
 ]
 
 [[package]]
@@ -341,7 +368,7 @@ dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/e0/633e369b91bbc664df47dcb5454b6c7cf441e8f5b9d0c250ce9f0546401e/virtualenv-20.30.0.tar.gz", hash = "sha256:800863162bcaa5450a6e4d721049730e7f2dae07720e0902b0e4040bd6f9ada8", size = 4346945, upload_time = "2025-03-31T16:33:29.185Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/e0/633e369b91bbc664df47dcb5454b6c7cf441e8f5b9d0c250ce9f0546401e/virtualenv-20.30.0.tar.gz", hash = "sha256:800863162bcaa5450a6e4d721049730e7f2dae07720e0902b0e4040bd6f9ada8", size = 4346945 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/ed/3cfeb48175f0671ec430ede81f628f9fb2b1084c9064ca67ebe8c0ed6a05/virtualenv-20.30.0-py3-none-any.whl", hash = "sha256:e34302959180fca3af42d1800df014b35019490b119eba981af27f2fa486e5d6", size = 4329461, upload_time = "2025-03-31T16:33:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ed/3cfeb48175f0671ec430ede81f628f9fb2b1084c9064ca67ebe8c0ed6a05/virtualenv-20.30.0-py3-none-any.whl", hash = "sha256:e34302959180fca3af42d1800df014b35019490b119eba981af27f2fa486e5d6", size = 4329461 },
 ]


### PR DESCRIPTION
This PR adds in [Ruff](https://github.com/astral-sh/ruff), it's a formatter/linter by the same devs as `uv`. In this PR it's set up for formatting only. It has drop-in parity with `black`, but it's a lot faster.

The code has been formatted, it's in the pyproject.toml, and I also set it up to automatically verify PRs as a github action. Let me know if there's anything you'd have me set up differently on this, happy to swap it over to black or something if you prefer.