### PR TITLE
Bind /tmp/docker.sock in backup spawned container

### DIFF
--- a/src/restic_compose_backup/backup_runner.py
+++ b/src/restic_compose_backup/backup_runner.py
@@ -17,6 +17,7 @@ def run(
     logger.info("Starting backup container")
     client = utils.docker_client()
 
+    volumes["/var/run/docker.sock"] = {"bind": "/tmp/docker.sock", "mode": "ro"};
     container = client.containers.run(
         image,
         command,


### PR DESCRIPTION
Possibly addresses issue #83: override volumes for the backup runner so the backup process container gets a direct mount of the socket.  Otherwise the verb `status` works but `backup` generates the following error because `self.unix_socket` (value `/tmp/docker.sock`) is not mounted inside the backup container:

```
Traceback (most recent call last):
  File "/restic-compose-backup/.venv/lib/python3.14/site-packages/urllib3/connectionpool.py", line 787, in urlopen
    response = self._make_request(
        conn,
    ...<10 lines>...
        **response_kw,
    )
  File "/restic-compose-backup/.venv/lib/python3.14/site-packages/urllib3/connectionpool.py", line 493, in _make_request
    conn.request(
    ~~~~~~~~~~~~^
        method,
        ^^^^^^^
    ...<6 lines>...
        enforce_content_length=enforce_content_length,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/restic-compose-backup/.venv/lib/python3.14/site-packages/urllib3/connection.py", line 445, in request
    self.endheaders()
    ~~~~~~~~~~~~~~~^^
  File "/root/.local/share/uv/python/cpython-3.14.0-linux-x86_64-musl/lib/python3.14/http/client.py", line 1333, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/uv/python/cpython-3.14.0-linux-x86_64-musl/lib/python3.14/http/client.py", line 1093, in _send_output
    self.send(msg)
    ~~~~~~~~~^^^^^
  File "/root/.local/share/uv/python/cpython-3.14.0-linux-x86_64-musl/lib/python3.14/http/client.py", line 1037, in send
    self.connect()
    ~~~~~~~~~~~~^^
  File "/restic-compose-backup/.venv/lib/python3.14/site-packages/docker/transport/unixconn.py", line 26, in connect
    sock.connect(self.unix_socket)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory
```