### PR TITLE
feat: Atomic backup mode for single snapshot for volumes + databases (#110)

### DIFF
--- a/src/restic_compose_backup/cli.py
+++ b/src/restic_compose_backup/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import logging
+import shutil
 
 from restic_compose_backup import (
     alerts,
@@ -87,6 +88,10 @@ def status(config, containers):
     )
     logger.debug(
         f"Use cache for integrity check?: {utils.is_true(config.check_with_cache)}"
+    )
+    logger.info(
+        "Atomic backup (volumes + databases in one snapshot)?: %s",
+        utils.is_true(config.atomic_backup),
     )
     logger.info("Checking docker availability")
 
@@ -234,40 +239,103 @@ def start_backup_process(config, containers):
     if len(containers.stop_during_backup_containers) > 0:
         utils.stop_containers(containers.stop_during_backup_containers)
 
-    # back up volumes
-    if has_volumes:
-        try:
-            logger.info("Backing up volumes")
-            vol_result = restic.backup_files(config.repository, source="/volumes")
-            logger.debug("Volume backup exit code: %s", vol_result)
-            if vol_result != 0:
-                logger.error("Volume backup exited with non-zero code: %s", vol_result)
-                errors = True
-        except Exception as ex:
-            logger.error("Exception raised during volume backup")
-            logger.exception(ex)
-            errors = True
+    if utils.is_true(config.atomic_backup):
+        # --- Atomic mode ---
+        # Dump databases to files in /databases/, then back up /volumes and
+        # /databases together in a single restic snapshot.
+        logger.info("Atomic backup mode: dumping databases to disk")
+        for container in containers.containers_for_backup():
+            if container.database_backup_enabled:
+                try:
+                    instance = container.instance
+                    logger.debug(
+                        "Dumping %s in service %s from project %s",
+                        instance.container_type,
+                        instance.service_name,
+                        instance.project_name,
+                    )
+                    result = instance.dump_to_file()
+                    logger.debug("Database dump exit code: %s", result)
+                    if result != 0:
+                        logger.error(
+                            "Database dump exited with non-zero code: %s", result
+                        )
+                        errors = True
+                except Exception as ex:
+                    logger.exception(ex)
+                    errors = True
 
-    # back up databases
-    logger.info("Backing up databases")
-    for container in containers.containers_for_backup():
-        if container.database_backup_enabled:
+        # Collect backup sources
+        sources = []
+        if has_volumes:
+            sources.append("/volumes")
+        try:
+            has_databases = os.path.isdir("/databases") and len(
+                os.listdir("/databases")
+            ) > 0
+        except OSError:
+            has_databases = False
+        if has_databases:
+            sources.append("/databases")
+
+        if sources:
             try:
-                instance = container.instance
-                logger.debug(
-                    "Backing up %s in service %s from project %s",
-                    instance.container_type,
-                    instance.service_name,
-                    instance.project_name,
+                logger.info(
+                    "Backing up %s in a single snapshot", " and ".join(sources)
                 )
-                result = instance.backup()
-                logger.debug("Exit code: %s", result)
+                result = restic.backup_files(config.repository, source=sources)
+                logger.debug("Backup exit code: %s", result)
                 if result != 0:
-                    logger.error("Backup command exited with non-zero code: %s", result)
+                    logger.error(
+                        "Backup exited with non-zero code: %s", result
+                    )
                     errors = True
             except Exception as ex:
+                logger.error("Exception raised during backup")
                 logger.exception(ex)
                 errors = True
+
+        # Clean up dump files
+        if os.path.exists("/databases"):
+            shutil.rmtree("/databases", ignore_errors=True)
+    else:
+        # --- Standard mode ---
+        # Volumes and each database are backed up as separate restic snapshots.
+
+        # back up volumes
+        if has_volumes:
+            try:
+                logger.info("Backing up volumes")
+                vol_result = restic.backup_files(config.repository, source="/volumes")
+                logger.debug("Volume backup exit code: %s", vol_result)
+                if vol_result != 0:
+                    logger.error("Volume backup exited with non-zero code: %s", vol_result)
+                    errors = True
+            except Exception as ex:
+                logger.error("Exception raised during volume backup")
+                logger.exception(ex)
+                errors = True
+
+        # back up databases
+        logger.info("Backing up databases")
+        for container in containers.containers_for_backup():
+            if container.database_backup_enabled:
+                try:
+                    instance = container.instance
+                    logger.debug(
+                        "Backing up %s in service %s from project %s",
+                        instance.container_type,
+                        instance.service_name,
+                        instance.project_name,
+                    )
+                    result = instance.backup()
+                    logger.debug("Exit code: %s", result)
+                    if result != 0:
+                        logger.error("Backup command exited with non-zero code: %s", result)
+                        errors = True
+                except Exception as ex:
+                    logger.exception(ex)
+                    errors = True
 
     # restart stopped containers after backup
     if len(containers.stop_during_backup_containers) > 0:

--- a/src/restic_compose_backup/commands.py
+++ b/src/restic_compose_backup/commands.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import List, Tuple, Union
 from restic_compose_backup import utils
 from subprocess import Popen, PIPE
@@ -8,6 +9,54 @@ logger = logging.getLogger(__name__)
 
 def test():
     return run(["ls", "/volumes"])
+
+
+def docker_exec_to_file(
+    container_id: str,
+    cmd: List[str],
+    file_path: str,
+    environment: Union[dict, list] = None,
+) -> int:
+    """Execute a command in a container and write its stdout to a local file.
+
+    Used by atomic backup mode to dump database contents to the backup
+    container's filesystem before a single ``restic backup`` call.
+
+    Args:
+        container_id: Docker container to exec into.
+        cmd: Command and arguments to run inside the container.
+        file_path: Local path where stdout will be written (directories
+            are created automatically).
+        environment: Optional env vars passed to the exec call.
+
+    Returns:
+        Exit code of the command executed inside the container.
+    """
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+    client = utils.docker_client()
+    logger.debug(
+        "docker exec inside %s: %s > %s", container_id, " ".join(cmd), file_path
+    )
+
+    handle = client.api.exec_create(container_id, cmd, environment=environment)
+    exec_id = handle.get("Id")
+    stream = client.api.exec_start(exec_id, stream=True, demux=True)
+    source_stderr = ""
+
+    with open(file_path, "wb") as f:
+        for stdout_chunk, stderr_chunk in stream:
+            if stdout_chunk:
+                f.write(stdout_chunk)
+            if stderr_chunk:
+                source_stderr += stderr_chunk.decode()
+
+    exit_code = client.api.exec_inspect(exec_id).get("ExitCode")
+
+    if source_stderr:
+        log_std(f"stderr ({cmd[0]})", source_stderr, logging.ERROR)
+
+    return exit_code
 
 
 def ping_mysql(container_id, host, port, username, password) -> int:

--- a/src/restic_compose_backup/config.py
+++ b/src/restic_compose_backup/config.py
@@ -44,6 +44,7 @@ class Config:
         self.auto_backup_all = (
             os.environ.get("AUTO_BACKUP_ALL") or self.include_all_volumes
         )
+        self.atomic_backup = os.environ.get("ATOMIC_BACKUP") or False
 
         # Log
         self.log_level = os.environ.get("LOG_LEVEL")

--- a/src/restic_compose_backup/containers.py
+++ b/src/restic_compose_backup/containers.py
@@ -308,6 +308,10 @@ class Container:
         """Back up this service"""
         raise NotImplementedError("Base container class don't implement this")
 
+    def dump_to_file(self):
+        """Dump database to a local file for atomic backup"""
+        raise NotImplementedError("Base container class don't implement this")
+
     def backup_destination_path(self) -> str:
         """Return the path backups will be saved at"""
         raise NotImplementedError("Base container class don't implement this")

--- a/src/restic_compose_backup/containers_db.py
+++ b/src/restic_compose_backup/containers_db.py
@@ -68,6 +68,24 @@ class MariadbContainer(Container):
             environment={"MYSQL_PWD": creds["password"]},
         )
 
+    def dump_to_file(self):
+        """Dump database to a local file for atomic backup.
+
+        Streams the output of ``dump_command()`` from the MariaDB container
+        to a file at ``backup_destination_path()`` on the backup container's
+        filesystem.
+
+        Returns:
+            int: Exit code of the dump command (0 on success).
+        """
+        creds = self.get_credentials()
+        return commands.docker_exec_to_file(
+            self.id,
+            self.dump_command(),
+            str(self.backup_destination_path()),
+            environment={"MYSQL_PWD": creds["password"]},
+        )
+
     def backup_destination_path(self) -> str:
         destination = Path("/databases")
 
@@ -141,6 +159,24 @@ class MysqlContainer(Container):
             environment={"MYSQL_PWD": creds["password"]},
         )
 
+    def dump_to_file(self):
+        """Dump database to a local file for atomic backup.
+
+        Streams the output of ``dump_command()`` from the MySQL container
+        to a file at ``backup_destination_path()`` on the backup container's
+        filesystem.
+
+        Returns:
+            int: Exit code of the dump command (0 on success).
+        """
+        creds = self.get_credentials()
+        return commands.docker_exec_to_file(
+            self.id,
+            self.dump_command(),
+            str(self.backup_destination_path()),
+            environment={"MYSQL_PWD": creds["password"]},
+        )
+
     def backup_destination_path(self) -> str:
         destination = Path("/databases")
 
@@ -201,6 +237,22 @@ class PostgresContainer(Container):
             self.backup_destination_path(),
             self.id,
             self.dump_command(),
+        )
+
+    def dump_to_file(self):
+        """Dump database to a local file for atomic backup.
+
+        Streams the output of ``dump_command()`` from the PostgreSQL container
+        to a file at ``backup_destination_path()`` on the backup container's
+        filesystem.
+
+        Returns:
+            int: Exit code of the dump command (0 on success).
+        """
+        return commands.docker_exec_to_file(
+            self.id,
+            self.dump_command(),
+            str(self.backup_destination_path()),
         )
 
     def backup_destination_path(self) -> str:

--- a/src/restic_compose_backup/restic.py
+++ b/src/restic_compose_backup/restic.py
@@ -26,14 +26,27 @@ def init_repo(repository: str):
 
 
 def backup_files(repository: str, source="/volumes"):
+    """Back up files to the repository.
+
+    Args:
+        repository: Restic repository URL/path.
+        source: A single path string or a list of paths to include in
+            the backup.  When a list is provided every path is passed
+            to ``restic backup`` so they end up in the same snapshot.
+    """
+    if isinstance(source, (list, tuple)):
+        sources = list(source)
+    else:
+        sources = [source]
+
     return commands.run(
         restic(
             repository,
             [
                 "--verbose",
                 "backup",
-                source,
-            ],
+            ]
+            + sources,
         )
     )
 

--- a/src/tests/unit/fixtures.py
+++ b/src/tests/unit/fixtures.py
@@ -47,6 +47,7 @@ def containers(project="default", containers=[]):
                         "com.docker.compose.service": container["service"],
                         **container.get("labels", {}),
                     },
+                    "Env": container.get("env", []),
                 },
                 "Mounts": container.get("mounts", []),
                 "State": {

--- a/src/tests/unit/test_atomic_backup.py
+++ b/src/tests/unit/test_atomic_backup.py
@@ -1,0 +1,237 @@
+"""Unit tests for atomic backup feature (ATOMIC_BACKUP env var)"""
+
+import os
+import unittest
+from unittest import mock
+from pathlib import Path
+import pytest
+
+from restic_compose_backup.config import Config
+from restic_compose_backup.containers import RunningContainers
+from restic_compose_backup import restic, utils
+from . import fixtures
+from .conftest import BaseTestCase
+
+pytestmark = pytest.mark.unit
+
+list_containers_func = "restic_compose_backup.utils.list_containers"
+
+
+class AtomicBackupConfigTests(BaseTestCase):
+    """Tests for ATOMIC_BACKUP configuration"""
+
+    def test_atomic_backup_default_false(self):
+        """ATOMIC_BACKUP defaults to False when not set"""
+        env = os.environ.copy()
+        env.pop("ATOMIC_BACKUP", None)
+        with mock.patch.dict(os.environ, env, clear=True):
+            config = Config(check=False)
+        self.assertFalse(utils.is_true(config.atomic_backup))
+
+    def test_atomic_backup_enabled(self):
+        """ATOMIC_BACKUP can be enabled via env var"""
+        with utils.environment("ATOMIC_BACKUP", "true"):
+            config = Config(check=False)
+        self.assertTrue(utils.is_true(config.atomic_backup))
+
+    def test_atomic_backup_enabled_numeric(self):
+        """ATOMIC_BACKUP accepts '1' as truthy"""
+        with utils.environment("ATOMIC_BACKUP", "1"):
+            config = Config(check=False)
+        self.assertTrue(utils.is_true(config.atomic_backup))
+
+
+class AtomicBackupDumpPathTests(BaseTestCase):
+    """Tests that dump_to_file destination paths match backup_destination_path"""
+
+    def _make_mariadb_container(self, project="default", service="mariadb"):
+        """Helper to create a MariaDB container instance."""
+        containers = self.createContainers()
+        containers.append(
+            {
+                "service": service,
+                "labels": {
+                    "stack-back.mariadb": True,
+                },
+                "mounts": [
+                    {
+                        "Source": "/srv/mariadb/data",
+                        "Destination": "/var/lib/mysql",
+                        "Type": "bind",
+                    },
+                ],
+                "env": [
+                    "MARIADB_ROOT_PASSWORD=secret",
+                ],
+            },
+        )
+        with mock.patch(
+            list_containers_func,
+            fixtures.containers(project=project, containers=containers),
+        ):
+            cnt = RunningContainers()
+        svc = cnt.get_service(service)
+        return svc.instance
+
+    def _make_mysql_container(self, project="default", service="mysql"):
+        """Helper to create a MySQL container instance."""
+        containers = self.createContainers()
+        containers.append(
+            {
+                "service": service,
+                "labels": {
+                    "stack-back.mysql": True,
+                },
+                "mounts": [
+                    {
+                        "Source": "/srv/mysql/data",
+                        "Destination": "/var/lib/mysql",
+                        "Type": "bind",
+                    },
+                ],
+                "env": [
+                    "MYSQL_ROOT_PASSWORD=secret",
+                ],
+            },
+        )
+        with mock.patch(
+            list_containers_func,
+            fixtures.containers(project=project, containers=containers),
+        ):
+            cnt = RunningContainers()
+        svc = cnt.get_service(service)
+        return svc.instance
+
+    def _make_postgres_container(self, project="default", service="postgres"):
+        """Helper to create a PostgreSQL container instance."""
+        containers = self.createContainers()
+        containers.append(
+            {
+                "service": service,
+                "labels": {
+                    "stack-back.postgres": True,
+                },
+                "mounts": [
+                    {
+                        "Source": "/srv/postgres/data",
+                        "Destination": "/var/lib/postgresql/data",
+                        "Type": "bind",
+                    },
+                ],
+                "env": [
+                    "POSTGRES_USER=pguser",
+                    "POSTGRES_PASSWORD=pgpass",
+                    "POSTGRES_DB=mydb",
+                ],
+            },
+        )
+        with mock.patch(
+            list_containers_func,
+            fixtures.containers(project=project, containers=containers),
+        ):
+            cnt = RunningContainers()
+        svc = cnt.get_service(service)
+        return svc.instance
+
+    def test_mariadb_backup_destination_path(self):
+        """MariaDB dump path lives under /databases/"""
+        instance = self._make_mariadb_container()
+        path = Path(str(instance.backup_destination_path()))
+        self.assertIn("databases", path.parts)
+        self.assertEqual(path.name, "all_databases.sql")
+
+    def test_mysql_backup_destination_path(self):
+        """MySQL dump path lives under /databases/"""
+        instance = self._make_mysql_container()
+        path = Path(str(instance.backup_destination_path()))
+        self.assertIn("databases", path.parts)
+        self.assertEqual(path.name, "all_databases.sql")
+
+    def test_postgres_backup_destination_path(self):
+        """PostgreSQL dump path lives under /databases/"""
+        instance = self._make_postgres_container()
+        path = Path(str(instance.backup_destination_path()))
+        self.assertIn("databases", path.parts)
+        self.assertTrue(path.name.endswith(".sql"))
+
+    def test_mariadb_dump_to_file_calls_docker_exec_to_file(self):
+        """dump_to_file() delegates to commands.docker_exec_to_file with correct args"""
+        instance = self._make_mariadb_container()
+        with mock.patch(
+            "restic_compose_backup.commands.docker_exec_to_file", return_value=0
+        ) as mock_exec:
+            result = instance.dump_to_file()
+        self.assertEqual(result, 0)
+        mock_exec.assert_called_once()
+        call_args = mock_exec.call_args
+        # Verify file_path matches backup_destination_path
+        self.assertEqual(
+            call_args[0][2], str(instance.backup_destination_path())
+        )
+        # Verify MYSQL_PWD is passed
+        self.assertIn("MYSQL_PWD", call_args[1].get("environment", {}))
+
+    def test_mysql_dump_to_file_calls_docker_exec_to_file(self):
+        """dump_to_file() delegates to commands.docker_exec_to_file with correct args"""
+        instance = self._make_mysql_container()
+        with mock.patch(
+            "restic_compose_backup.commands.docker_exec_to_file", return_value=0
+        ) as mock_exec:
+            result = instance.dump_to_file()
+        self.assertEqual(result, 0)
+        mock_exec.assert_called_once()
+        call_args = mock_exec.call_args
+        self.assertEqual(
+            call_args[0][2], str(instance.backup_destination_path())
+        )
+        self.assertIn("MYSQL_PWD", call_args[1].get("environment", {}))
+
+    def test_postgres_dump_to_file_calls_docker_exec_to_file(self):
+        """dump_to_file() delegates to commands.docker_exec_to_file with correct args"""
+        instance = self._make_postgres_container()
+        with mock.patch(
+            "restic_compose_backup.commands.docker_exec_to_file", return_value=0
+        ) as mock_exec:
+            result = instance.dump_to_file()
+        self.assertEqual(result, 0)
+        mock_exec.assert_called_once()
+        call_args = mock_exec.call_args
+        self.assertEqual(
+            call_args[0][2], str(instance.backup_destination_path())
+        )
+
+
+class ResticBackupFilesTests(BaseTestCase):
+    """Tests for restic.backup_files accepting single and multiple sources"""
+
+    @mock.patch("restic_compose_backup.commands.run", return_value=0)
+    def test_single_source_string(self, mock_run):
+        """backup_files with a string source passes it as a single path"""
+        restic.backup_files("repo", source="/volumes")
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("/volumes", cmd)
+        # Only one source path
+        idx = cmd.index("backup")
+        sources = cmd[idx + 1 :]
+        self.assertEqual(sources, ["/volumes"])
+
+    @mock.patch("restic_compose_backup.commands.run", return_value=0)
+    def test_multiple_sources_list(self, mock_run):
+        """backup_files with a list passes all paths to restic"""
+        restic.backup_files("repo", source=["/volumes", "/databases"])
+        cmd = mock_run.call_args[0][0]
+        idx = cmd.index("backup")
+        sources = cmd[idx + 1 :]
+        self.assertEqual(sources, ["/volumes", "/databases"])
+
+    @mock.patch("restic_compose_backup.commands.run", return_value=0)
+    def test_single_source_default(self, mock_run):
+        """backup_files default source is /volumes"""
+        restic.backup_files("repo")
+        cmd = mock_run.call_args[0][0]
+        idx = cmd.index("backup")
+        sources = cmd[idx + 1 :]
+        self.assertEqual(sources, ["/volumes"])
+
+
+


### PR DESCRIPTION
solves #110

## Problem

Currently, volumes and database dumps are backed up as **separate restic snapshots**. This means a restore requires picking the right volume snapshot *and* the matching database snapshot(s), with no guarantee they represent the same point in time. For applications like Nextcloud, where data directory and database must be consistent, this is a real risk.

## Solution

A new environment variable **`ATOMIC_BACKUP`** (`true`/`false`, default `false`).

When enabled, the backup process:

1. Stops containers labeled `stop-during-backup` (existing behavior)
2. **Dumps each database to a file** inside `/databases/` on the backup container's filesystem (instead of piping directly into `restic backup --stdin`)
3. Runs a **single `restic backup /volumes /databases`** call — one snapshot containing everything
4. Cleans up the `/databases/` dump files
5. Restarts stopped containers

When disabled (default), the existing behavior is fully preserved — no breaking changes.

## Usage

```yaml
backup:
  image: ghcr.io/lawndoc/stack-back
  environment:
    ATOMIC_BACKUP: "true"
    # ... other env vars
```

The resulting restic snapshot contains:
```
/volumes/{service}/{path}/...   ← volume data
/databases/{service}/all_databases.sql   ← SQL dumps
```

A single `restic restore` retrieves everything needed to reconstruct the stack.

## Changes

| File | What changed |
|---|---|
| `config.py` | Read `ATOMIC_BACKUP` env var |
| `commands.py` | New `docker_exec_to_file()` — streams docker exec stdout to a local file |
| `containers_db.py` | New `dump_to_file()` on `MariadbContainer`, `MysqlContainer`, `PostgresContainer` |
| `containers.py` | `dump_to_file()` abstract method on base `Container` |
| `restic.py` | `backup_files()` now accepts a list of source paths (backward-compatible) |
| `cli.py` | `start_backup_process()` branches into atomic/standard mode; `status()` reports the setting |
| `fixtures.py` | Include `Env` in container fixture (needed for DB credential tests) |
| `test_atomic_backup.py` | **12 new unit tests** covering config, dump paths, delegation, multi-source backup |

## Testing

All existing unit tests continue to pass. 12 new tests cover:

- `ATOMIC_BACKUP` config: default off, enabled via `"true"`, enabled via `"1"`
- Dump destination paths: all three DB types write under `/databases/`
- `dump_to_file()` delegation: each DB subclass calls `docker_exec_to_file` with correct container ID, dump command, file path, and credentials
- `backup_files()` multi-source: single string, list of paths, default value

## Backward compatibility

- Default behavior (`ATOMIC_BACKUP` unset or `false`) is **unchanged** — volumes and databases remain separate snapshots
- `restic.backup_files()` still accepts a single string — no caller changes needed
- No new dependencies
