### PR TITLE
Add option to create snapshots per service

### DIFF
--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -128,7 +128,7 @@ Whether restic should use the local cache when checking for integrity
 of the repository. This is useful for reducing remote read operations,
 which may be charged by your cloud provider.
 
-The tradeoff is that there is a small risk of not detecting corrupted 
+The tradeoff is that there is a small risk of not detecting corrupted
 data in the repository if the remote is corrupted but the local cache is not.
 
 LOG_LEVEL
@@ -218,21 +218,21 @@ were we cannot map in the docker socket.
 AUTO_BACKUP_ALL
 ~~~~~~~~~~~~~~~~~~~
 
-If defined, all volumes and databases in the project will be 
-included in the backup. This removes the need to add labels to 
+If defined, all volumes and databases in the project will be
+included in the backup. This removes the need to add labels to
 each service when you want to back up everything.
 
-Database detection is based on the default images for mariadb, mysql 
-and postgres. When a database is detected, the volume associated with 
+Database detection is based on the default images for mariadb, mysql
+and postgres. When a database is detected, the volume associated with
 the database data is automatically excluded from the backup.
 
 Volumes can be excluded by adding the ``stack-back.volumes.exclude: <volume_name>``
 or ``stack-back.volumes: False`` label to the service.
 
 Databases can be excluded by adding the
-``stack-back.<db_type>: False`` label to the service along with 
-``stack-back.volumes: False``. Forgetting to also exclude the 
-volumes may result in a backup of the database files volume instead 
+``stack-back.<db_type>: False`` label to the service along with
+``stack-back.volumes: False``. Forgetting to also exclude the
+volumes may result in a backup of the database files volume instead
 of the database itself.
 
 INCLUDE_PROJECT_NAME
@@ -271,6 +271,14 @@ SWARM_MODE
 ~~~~~~~~~~
 
 If defined containers in swarm stacks are also evaluated.
+
+PER_SERVICE_SNAPSHOT
+~~~~~~~~~~
+
+**Default value**: ``false``
+
+Whether restic should create one snapshot per service.
+Otherwise, one snapshot with volumes from all services is created.
 
 Compose Labels
 --------------
@@ -330,15 +338,15 @@ Their path in restic will be:
 - /volumes/myservice/srv/data
 
 In situations where the files in the volume are at risk of being
-corrupted during the backup process (such as SQLite databases), 
-the `stack-back.volumes.stop-during-backup` label can be added to 
-the service. This will stop the service during the backup process 
+corrupted during the backup process (such as SQLite databases),
+the `stack-back.volumes.stop-during-backup` label can be added to
+the service. This will stop the service during the backup process
 and start it again when the backup is done.
 
 Example:
 
 .. code:: yaml
-  
+
     myservice:
       image: some_image
       labels:

--- a/src/restic_compose_backup/cli.py
+++ b/src/restic_compose_backup/cli.py
@@ -236,17 +236,30 @@ def start_backup_process(config, containers):
 
     # back up volumes
     if has_volumes:
-        try:
-            logger.info("Backing up volumes")
-            vol_result = restic.backup_files(config.repository, source="/volumes")
-            logger.debug("Volume backup exit code: %s", vol_result)
-            if vol_result != 0:
-                logger.error("Volume backup exited with non-zero code: %s", vol_result)
+        if config.per_service_snapshot:
+            backup_paths = [
+                os.path.join("/volumes", stack, service)
+                for stack in os.listdir("/volumes")
+                if os.path.isdir(os.path.join("/volumes", stack))
+                for service in os.listdir(os.path.join("/volumes", stack))
+                if os.path.isdir(os.path.join("/volumes", stack, service))
+            ]
+        else:
+            backup_paths = ["/volumes"]
+        for path in backup_paths:
+            logger.info(f"Backing up volume {path}")
+            try:
+                vol_result = restic.backup_files(config.repository, source=path)
+                logger.debug(f"Volume {path} backup exit code: {vol_result}")
+                if vol_result != 0:
+                    logger.error(
+                        f"Volume {path} backup exited with non-zero code: {vol_result}"
+                    )
+                    errors = True
+            except Exception as ex:
+                logger.error(f"Exception raised during backup of volume {path}")
+                logger.exception(ex)
                 errors = True
-        except Exception as ex:
-            logger.error("Exception raised during volume backup")
-            logger.exception(ex)
-            errors = True
 
     # back up databases
     logger.info("Backing up databases")

--- a/src/restic_compose_backup/config.py
+++ b/src/restic_compose_backup/config.py
@@ -1,6 +1,8 @@
 import logging
 import os
 
+from restic_compose_backup import utils
+
 logger = logging.getLogger(__name__)
 
 
@@ -62,6 +64,9 @@ class Config:
         )
         self.keep_yearly = (
             os.environ.get("RESTIC_KEEP_YEARLY") or os.environ.get("KEEP_YEARLY") or "3"
+        )
+        self.per_service_snapshot = utils.is_true(
+            os.environ.get("PER_SERVICE_SNAPSHOT")
         )
 
         if check:


### PR DESCRIPTION
Hello, thank you for creating an maintaining this service, it is very useful.

## Changes in this PR
A new boolean parameter `PER_SERVICE_SNAPSHOT` is added which allows to switch from creating one snapshot for all services to one snapshot per service. The old behavior remains the default to not break existing setups.

## Why this is necessary
I have stack-back setup to create daily backups and keep a finite number of daily, weekly and monthly snapshots. I also recently decommissioned and stopped a service that I no longer use, but I would still like to keep backups of. I expected to keep X daily/weekly/monthly snapshots, but because stack-back does not back up stopped stacks so newer snapshots don't include the data of the stopped stack, eventually all old snapshots with data of the stopped stack will be pruned so no backup of the stopped stack will exist. Keeping snapshots per service circumvents that problem because the pruning works per path and for a stopped service no new snapshots are generated with it's path, so there will always remain some snapshots according to the retention settings.

Closes #106 I believe.