### PR TITLE
Surface restic errors in the container logs

### DIFF
--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -90,7 +90,7 @@ env variables.
 CRON_COMMAND
 ~~~~~~~~~~~~
 
-**Default value**: ``source /env.sh && rcb backup > /proc/1/fd/1``
+**Default value**: ``source /env.sh && rcb backup > /proc/1/fd/1 2> /proc/1/fd/2``
 
 The command executed in the crontab. A single line is generated when
 the container starts from the ``CRON_SCHEDULE`` and ``CRON_COMMAND``
@@ -102,7 +102,7 @@ docker logs.
 
 By default the crontab will look like this::
 
-    0 2 * * * source /env.sh && rcb backup > /proc/1/fd/1
+    0 2 * * * source /env.sh && rcb backup > /proc/1/fd/1 2> /proc/1/fd/2
 
 MAINTENANCE_SCHEDULE
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/guide/rcb.rst
+++ b/docs/guide/rcb.rst
@@ -169,7 +169,7 @@ the container starts. It can be user to verify the configuration.
 Example output::
 
     /stack-back # rcb crontab
-    10 2 * * * source /env.sh && rcb backup > /proc/1/fd/1
+    10 2 * * * source /env.sh && rcb backup > /proc/1/fd/1 2> /proc/1/fd/2
 
 cleanup
 ~~~~~~~

--- a/src/crontab
+++ b/src/crontab
@@ -1,2 +1,2 @@
-10 2 * * * source /.env && rcb backup > /proc/1/fd/1
+10 2 * * * source /.env && rcb backup > /proc/1/fd/1 2> /proc/1/fd/2
 

--- a/src/restic_compose_backup/config.py
+++ b/src/restic_compose_backup/config.py
@@ -5,9 +5,11 @@ logger = logging.getLogger(__name__)
 
 
 class Config:
-    default_backup_command = "source /.env && rcb backup > /proc/1/fd/1"
+    default_backup_command = "source /.env && rcb backup > /proc/1/fd/1 2> /proc/1/fd/2"
     default_crontab_schedule = "0 2 * * *"
-    default_maintenance_command = "source /.env && rcb maintenance > /proc/1/fd/1"
+    default_maintenance_command = (
+        "source /.env && rcb maintenance > /proc/1/fd/1 2> /proc/1/fd/2"
+    )
 
     """Bag for config values"""
 


### PR DESCRIPTION
## Changes in this PR
Change the default value of the `CRON_COMMAND` configuration to also capture the stderr stream of the restic command.

## Why it is needed
`command > destination` only redirects the stdout of the `command` to the `destination`, but the stderr is not captured (see [the bash documentation](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Redirecting-Output)). All error output from the restic command was not included in the container logs, which made it very difficult to debug when it was misconfigured.